### PR TITLE
Adds search bar to samples and scenarios views

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,8 @@
         "curly": "warn",
         "eqeqeq": "warn",
         "no-throw-literal": "warn",
-        "semi": "off"
+        "semi": "off",
+        "no-console": "error"
     },
     "ignorePatterns": [
         "out",

--- a/src/webview/view/components/gallery/GalleryView.tsx
+++ b/src/webview/view/components/gallery/GalleryView.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
+import { useEffect, useState } from 'react';
 import useSamples from '../../hooks/useSamples';
 import { VSCodeProgressRing } from '@vscode/webview-ui-toolkit/react';
 import { List } from './List';
 import { LibraryIcon } from '../icons/LibraryIcon';
+import { SearchBar } from './SearchBar';
 
 export type GalleryType = 'samples' | 'scenarios';
 
@@ -11,7 +13,18 @@ export interface IGalleryViewProps {
 }
 
 export const GalleryView: React.FunctionComponent<IGalleryViewProps> = ({type}: React.PropsWithChildren<IGalleryViewProps>) => {
-  const { samples } = useSamples(type);
+  const [samples, search] = useSamples(type);
+  const [query, setQuery] = useState<string>('');
+  
+  const onSampleSearch = (event: any) => {
+    const input: string = event.target.value;
+    setQuery(input);
+    search(input);
+  };
+
+  useEffect(() => {
+    setQuery('');
+  }, [type]);
 
   return (
     <div className="w-full h-full max-w-7xl mx-auto sm:px-6 lg:px-8 py-16">
@@ -31,21 +44,10 @@ export const GalleryView: React.FunctionComponent<IGalleryViewProps> = ({type}: 
       }
 
       {
-        samples !== undefined && samples.length === 0 && (
-          <div className="flex justify-center items-center h-full">
-            <div className="text-center h-16">
-              <p className='mt-4 text-xl'>No {type} found.</p>
-            </div>
-          </div>
-        )
-      }
-
-      {
-        samples !== undefined && samples.length > 0 && (
+        samples !== undefined && (
           <div className='pb-16'>
             <div className={`flex items-center`}>
               <LibraryIcon className={`sample__icon w-16`} />
-
               <div className={`ml-4`}>
                 <h1 className='text-2xl first-letter:uppercase'>{type}</h1>
                 {
@@ -60,8 +62,24 @@ export const GalleryView: React.FunctionComponent<IGalleryViewProps> = ({type}: 
                 }
               </div>
             </div>
+            <SearchBar onSearch={(event) => onSampleSearch(event)} initialQuery={query}/>
 
-            <List items={samples} />
+            {
+              samples.length === 0 && (
+                <div className="flex justify-center items-center h-full">
+                  <div className="text-center h-16">
+                    <p className='mt-4 text-xl'>No {type} found.</p>
+                  </div>
+                </div>
+              )
+            }
+
+            {
+              samples.length > 0 && (
+                  <List items={samples} />
+              )
+            }
+
           </div>
         )
       }

--- a/src/webview/view/components/gallery/List.tsx
+++ b/src/webview/view/components/gallery/List.tsx
@@ -8,6 +8,7 @@ export interface IListProps {
   items: Sample[];
 }
 
+const INITIAL_PAGE = 0;
 const NR_OF_ITEMS = 12;
 
 export const List: React.FunctionComponent<IListProps> = ({ items }: React.PropsWithChildren<IListProps>) => {
@@ -15,16 +16,20 @@ export const List: React.FunctionComponent<IListProps> = ({ items }: React.Props
   const [pagedItems, setPagedItems] = useState<Sample[]>([]);
 
   useEffect(() => {
-    const newSet = items.slice(page * NR_OF_ITEMS, page * NR_OF_ITEMS + NR_OF_ITEMS);
+    setPage(INITIAL_PAGE);
+    setPagedItems(getNewSet(INITIAL_PAGE));
+  }, []);
 
-    setPagedItems(newSet);
+  useEffect(() => {
+    setPage(INITIAL_PAGE);
+    setPagedItems(getNewSet(INITIAL_PAGE));
   }, [items]);
 
   useEffect(() => {
-    const newSet = items.slice(page * NR_OF_ITEMS, page * NR_OF_ITEMS + NR_OF_ITEMS);
-
-    setPagedItems(newSet);
+    setPagedItems(getNewSet(page));
   }, [page, items]);
+
+  const getNewSet = (page: number): Sample[] => items.slice(page * NR_OF_ITEMS, page * NR_OF_ITEMS + NR_OF_ITEMS);
 
   if (!pagedItems || pagedItems.length === 0) {
     return null;

--- a/src/webview/view/components/gallery/SearchBar.tsx
+++ b/src/webview/view/components/gallery/SearchBar.tsx
@@ -1,0 +1,29 @@
+import { VSCodeTextField } from '@vscode/webview-ui-toolkit/react';
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import { SearchIcon } from '../icons/SearchIcon';
+
+export interface ISearchBarProps {
+  onSearch: (event: any) => void;
+  initialQuery?: string;
+}
+
+export const SearchBar: React.FunctionComponent<ISearchBarProps> = ({ onSearch, initialQuery }: React.PropsWithChildren<ISearchBarProps>) => {
+  const [query, setQuery] = useState<string>('');
+
+  useEffect(() => {
+    setQuery(initialQuery ?? '');
+  }, [initialQuery]);
+  
+  return (
+    <div className={`flex`}>
+      <div className={`pl-6 pr-6 w-2/5`}>
+        <VSCodeTextField size="100" placeholder="Search" value={query} onInput={onSearch}>
+          <span slot='start' className='mt-0'>
+            <SearchIcon />
+          </span>
+        </VSCodeTextField>
+      </div>
+    </div>
+  );
+};

--- a/src/webview/view/components/icons/SearchIcon.tsx
+++ b/src/webview/view/components/icons/SearchIcon.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export interface ISearchIconProps {}
+
+export const SearchIcon: React.FunctionComponent<ISearchIconProps> = (props: React.PropsWithChildren<ISearchIconProps>) => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M15.25 0a8.25 8.25 0 0 0-6.18 13.72L1 22.88l1.12 1l8.05-9.12A8.251 8.251 0 1 0 15.25.01V0zm0 15a6.75 6.75 0 1 1 0-13.5a6.75 6.75 0 0 1 0 13.5z"></path>
+    </svg>
+  );
+};


### PR DESCRIPTION
## 🎯 Aim

The aim of this PR is to add search functionality to both samples and scenarios view.

## ✅ Done

- [X] Added search icon
- [X] Added search component
- [X] Modified the gallery view to allow to search samples
- [X] Extended eslint to validate console.log (not part of the issue but done along the was)
- [X] Fixed bug 🪲🔨 that when we switch pages (to like 2 page) in samples and moved to scenarios view we got no items as there was no 2 page in scenarios. We needed to clear view to 1 page when switching sample type

## 📸 Result

Movie how it works
https://user-images.githubusercontent.com/58668583/215363964-a834e73d-f83c-495a-a5fc-49f234d8acc8.mp4

## 🔗 Issue

Closes: #5


