### PR TITLE
Fixes missing letter in gulp command. Closes: #92

### DIFF
--- a/src/services/Terminal.ts
+++ b/src/services/Terminal.ts
@@ -85,7 +85,7 @@ export class Terminal {
 
     if (terminal) {
       terminal.show(true);
-      terminal.sendText(command);
+      terminal.sendText(` ${command}`);
     }
   }
 }


### PR DESCRIPTION
## 🎯 Aim

The aim is to resolve a strange issue of missing first letter in gulp command when booting up terminal of running task.

## ✅ What was done

- [X] Added Hacky fix with adding space at the beginning 

## 🔗 Related issue

 Closes: #92