### PR TITLE
Refactor CLI for M365 dependency to local version and bug fixes. Closes: #103 #82 #81

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -9,14 +9,39 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
 
       - name: Install the dependencies
         run: npm i
 
-      - name: Publish
-        run: npx vsce publish -p ${{ secrets.VSCE_PAT }} --pre-release --baseImagesUrl https://raw.githubusercontent.com/pnp/vscode-viva/dev
+      - name: Checkout cli-microsoft365
+        uses: actions/checkout@v3
+        with:
+          repository: Adam-it/cli-microsoft365
+          path: cli-microsoft365
+          ref: cli-cjs
+
+      - run: |
+          dir
+
+      - run: .\scripts\cli-for-microsoft365-copy-local-version.ps1 -workspacePath "${{ github.workspace }}"
+        shell: pwsh
+        continue-on-error: false
+
+      - run: .\scripts\cli-for-microsoft365-cleanup.ps1 -workspacePath "${{ github.workspace }}"
+        shell: pwsh
+        continue-on-error: false
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: vsix_package
+          path: |
+            *.vsix
+
+      #TODO: uncomment when ready to publish
+      # - name: Publish
+      #   run: npx vsce publish -p ${{ secrets.VSCE_PAT }} --pre-release --baseImagesUrl https://raw.githubusercontent.com/pnp/vscode-viva/dev

--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -1,11 +1,11 @@
-name: Pre-Release
+name: Create .vsix package
 
 on:
   workflow_dispatch:
 
 jobs:
   build:
-    name: "Build and pre-release"
+    name: "Build and package"
     runs-on: ubuntu-latest
 
     steps:
@@ -53,5 +53,14 @@ jobs:
         shell: pwsh
         continue-on-error: false
 
-      - name: Publish
-        run: npx vsce publish -p ${{ secrets.VSCE_PAT }} --pre-release --baseImagesUrl https://raw.githubusercontent.com/pnp/vscode-viva/dev
+      - name: Package
+        run: |
+          npx vsce package
+        working-directory: vscode-viva
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: vsix_package
+          path: |
+            vscode-viva/*.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Main Release
+name: Release
 
 on:
   release:
@@ -12,14 +12,49 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - name: Setup node
+        uses: actions/setup-node@v3.8.1
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
-
+      
+      - name: Checkout vscode-viva
+        uses: actions/checkout@v3
+        with:
+          path: vscode-viva
+        
       - name: Install the dependencies
-        run: npm i
+        run: npm install
+        working-directory: vscode-viva
+
+      - name: Checkout cli-microsoft365
+        uses: actions/checkout@v3
+        with:
+          repository: Adam-it/cli-microsoft365
+          path: cli-microsoft365
+          ref: cli-cjs
+
+      - name: Print dir
+        run: |
+          dir
+
+      - name: Restore dependencies for cli-microsoft365
+        run: npm install
+        working-directory: cli-microsoft365
+
+      - name: Build cli-microsoft365
+        run: npm run build
+        working-directory: cli-microsoft365
+
+      - name: Run script copy local CLI for M365    
+        run: .\vscode-viva\scripts\cli-for-microsoft365-copy-local-version.ps1 -workspacePath "${{ github.workspace }}"
+        shell: pwsh
+        continue-on-error: false
+
+      - name: Run script clean local CLI for M365 dependency  
+        run: .\vscode-viva\scripts\cli-for-microsoft365-cleanup.ps1 -workspacePath "${{ github.workspace }}"
+        shell: pwsh
+        continue-on-error: false
 
       - name: Publish
         run: npx vsce publish -p ${{ secrets.VSCE_PAT }}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,3 +17,4 @@ webpack
 .github
 scripts
 data
+cli-microsoft365

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "viva-connections-toolkit",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "viva-connections-toolkit",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@pnp/cli-microsoft365": "^6.11.0"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "viva-connections-toolkit",
 	"displayName": "Viva Connections Toolkit",
-	"description": "With the Viva Connections Toolkit extension, you can create and manage your Viva Connections solutions on your tenant. All actions you need to perform during the development flow are at your fingertips. Extensions also works with any SharePoint Framework. This toolkit is provided by the community.",
-	"version": "2.0.0",
+	"description": "Viva Connections Toolkit aims to boost your productivity in developing and managing SharePoint Framework solutions helping at every stage of your development flow, from setting up your development workspace to deploying a solution straight to your tenant without the need to leave VS Code and now even create a CI/CD pipeline to introduce automate deployment of your app. This toolkit is provided by the community.",
+	"version": "2.0.1",
 	"publisher": "m365pnp",
 	"preview": false,
 	"homepage": "https://github.com/pnp/vscode-viva",

--- a/scripts/cli-for-microsoft365-cleanup.ps1
+++ b/scripts/cli-for-microsoft365-cleanup.ps1
@@ -1,0 +1,92 @@
+param ([string[]]$workspacePath)
+
+$cliPackagePath = "$workspacePath\vscode-viva\node_modules\@pnp\cli-microsoft365"
+
+if (Test-Path -Path $cliPackagePath -PathType Container) {
+    Write-Host "Cleaning up cli-microsoft365 package..."
+    Remove-Item -Path "$cliPackagePath\docs" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\chili" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\aad" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\adaptivecard" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\app" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\booking" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\context" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\file" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\flow" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\graph" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\onedrive" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\onenote" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\outlook" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\pa" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\planner" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\pp" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\purview" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\applicationcustomizer" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\apppage" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\cdn" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\commandset" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\contenttype" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\contenttypehub" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\customaction" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\eventreceiver" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\externaluser" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\feature" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\field" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\folder" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\file" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\group" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\hidedefaultthemes" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\homesite" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\hubsite" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\knowledgehub" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\list" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\listitem" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\mail" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\navigation" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\orgassetslibrary" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\orgnewssite" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\page" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\propertybag" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\report" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\search" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\sitedesign" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\sitescript" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\storageentity" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\term" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\theme" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\user" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\userprofile" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\spo\commands\web" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\search" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\skype" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\teams" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\tenant" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\todo" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\viva" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\dist\m365\yammer" -Recurse -Force -ErrorAction SilentlyContinue
+
+    Remove-Item -Path "$cliPackagePath\node_modules\@microsoft\microsoft-graph-types" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@types\adm-zip" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@types\inquirer" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@types\jmespath" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@types\json-to-ast" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@types\minimist" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@types\mocha" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@types\node" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@types\node-forge" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@types\semver" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@types\sinon" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@types\update-notifier" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@types\uuid" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@typescript-eslint\eslint-plugin" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\@typescript-eslint\parser" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\c8" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\eslint" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\eslint-plugin-cli-microsoft365" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\eslint-plugin-mocha" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\mocha" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\rimraf" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\sinon" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "$cliPackagePath\node_modules\source-map-support" -Recurse -Force -ErrorAction SilentlyContinue
+}
+

--- a/scripts/cli-for-microsoft365-copy-local-version.ps1
+++ b/scripts/cli-for-microsoft365-copy-local-version.ps1
@@ -1,0 +1,11 @@
+param ([string[]]$workspacePath)
+
+$cliPackagePath = "$workspacePath\vscode-viva\node_modules\@pnp\cli-microsoft365"
+$cliLocalProjectPath = "$workspacePath\cli-microsoft365"
+
+if (Test-Path -Path $cliPackagePath -PathType Container && Test-Path -Path $cliLocalProjectPath -PathType Container) {
+    Write-Host "Coping local version of cli-microsoft365..."
+
+    Copy-Item -Path "$cliLocalProjectPath\dist\*" -Destination "$cliPackagePath\dist\" -Recurse -Force
+}
+

--- a/src/constants/AdaptiveCardTypes.ts
+++ b/src/constants/AdaptiveCardTypes.ts
@@ -1,4 +1,4 @@
-export const AdaptiveCardTypes = [
+export const AdaptiveCardTypesNode16 = [
   {
     name: 'Basic Card Template',
     value: 'Basic'
@@ -10,5 +10,16 @@ export const AdaptiveCardTypes = [
   {
     name: 'Primary Text Template',
     value: 'PrimaryText'
+  }
+];
+
+export const AdaptiveCardTypesNode18 = [
+  {
+    name: 'Generic Card Template',
+    value: 'Generic'
+  },
+  {
+    name: 'Search Query Modifier',
+    value: 'Search'
   }
 ];

--- a/src/constants/ExtensionTypes.ts
+++ b/src/constants/ExtensionTypes.ts
@@ -17,7 +17,7 @@ export const ExtensionTypes = [
   {
     name: 'Field Customizer',
     value: ExtensionType.field,
-    templates: ['react', 'minimal']
+    templates: ['React', 'Minimal', 'No framework']
   },
   {
     name: 'ListView Command Set',
@@ -27,7 +27,7 @@ export const ExtensionTypes = [
   {
     name: 'Form Customizer',
     value: ExtensionType.formCustomizer,
-    templates: ['react', 'none']
+    templates: ['React', 'No framework']
   },
   {
     name: 'Search Query Modifier',

--- a/src/providers/AuthProvider.ts
+++ b/src/providers/AuthProvider.ts
@@ -170,6 +170,8 @@ export class AuthProvider implements AuthenticationProvider, Disposable {
       return;
     }
 
+    EnvironmentInformation.account = undefined;
+
     Logger.info('M365 CLI - logged out');
     AuthProvider.login(false);
 

--- a/src/services/Dependencies.ts
+++ b/src/services/Dependencies.ts
@@ -8,7 +8,7 @@ import { Terminal } from './Terminal';
 import { Extension } from './Extension';
 
 
-const SUPPORTED_VERSIONS = ['16.13'];
+const SUPPORTED_VERSIONS = ['16.13', '18.12'];
 const DEPENDENCIES = ['gulp-cli', 'yo', '@microsoft/generator-sharepoint'];
 
 export class Dependencies {
@@ -41,7 +41,7 @@ export class Dependencies {
             // Validate node
             const isNodeValid = Dependencies.isValidNodeJs();
             if (!isNodeValid) {
-              Notifications.warning('Your Node.js version is not supported with SPFx development. Make sure you are using version: >=16.13 and <17.0');
+              Notifications.warning('Your Node.js version is not supported with SPFx development. Make sure you are using version: >=16.13 and <19.0');
               resolve(null);
               return;
             }

--- a/src/services/Dependencies.ts
+++ b/src/services/Dependencies.ts
@@ -41,7 +41,7 @@ export class Dependencies {
             // Validate node
             const isNodeValid = Dependencies.isValidNodeJs();
             if (!isNodeValid) {
-              Notifications.warning('Your Node.js version is not supported with SPFx development. Make sure you are using version: >=16.13 and <19.0');
+              Notifications.warning('Your Node.js version is not supported with SPFx development. Make sure you are using version: >=16.13 and <17.0 or >=18.12 and <19.0');
               resolve(null);
               return;
             }

--- a/src/services/Scaffolder.ts
+++ b/src/services/Scaffolder.ts
@@ -4,7 +4,7 @@ import { Folders } from './Folders';
 import { Notifications } from './Notifications';
 import { Logger } from './Logger';
 import { commands, ProgressLocation, QuickPickItem, Uri, window } from 'vscode';
-import { AdaptiveCardTypes, Commands, ComponentType, ComponentTypes, FrameworkTypes, ProjectFileContent } from '../constants';
+import { AdaptiveCardTypesNode16, AdaptiveCardTypesNode18, Commands, ComponentType, ComponentTypes, FrameworkTypes, ProjectFileContent } from '../constants';
 import { Sample, Subscription } from '../models';
 import { join } from 'path';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
@@ -14,6 +14,8 @@ import { Extension } from './Extension';
 import download from 'github-directory-downloader/esm';
 import { CliExecuter } from './CliCommandExecuter';
 import { getPlatform } from '../utils';
+import { Terminal } from './Terminal';
+import { execSync } from 'child_process';
 
 
 export const PROJECT_FILE = 'project.pnp';
@@ -308,7 +310,12 @@ export class Scaffolder {
    * @returns
    */
   private static async aceComponent(): Promise<{ aceTemplateType: NameValue, componentName: string } | undefined> {
-    const aceTemplateTypeChoice = await window.showQuickPick(AdaptiveCardTypes.map(ace => ace.name), {
+    const output = execSync('node --version', { shell: Terminal.shell });
+    const match = /v(?<major_version>\d+)\.(?<minor_version>\d+)\.(?<patch_version>\d+)/gm.exec(output.toString());
+    const nodeVersion = null === match ? '18' : match.groups?.major_version!;
+    const adaptiveCardTypes = nodeVersion === '16' ? AdaptiveCardTypesNode16 : AdaptiveCardTypesNode18;
+
+    const aceTemplateTypeChoice = await window.showQuickPick(adaptiveCardTypes.map(ace => ace.name), {
       title: 'Which adaptive card extension template do you want to use?',
       ignoreFocusOut: true,
       canPickMany: false
@@ -319,7 +326,7 @@ export class Scaffolder {
       return;
     }
 
-    const aceTemplateType = AdaptiveCardTypes.find(ace => ace.name === aceTemplateTypeChoice);
+    const aceTemplateType = adaptiveCardTypes.find(ace => ace.name === aceTemplateTypeChoice);
 
     const componentName = await window.showInputBox({
       title: 'What is your Adaptive Card Extension name?',

--- a/src/webview/PnPWebview.ts
+++ b/src/webview/PnPWebview.ts
@@ -190,7 +190,7 @@ export class PnPWebview {
       `script-src http: https: 'self' 'unsafe-inline' 'unsafe-eval'`,
       `img-src http: https: blob: data: 'self'`,
       `font-src 'self' https: ${isProd ? `` : `${localServer}:${devPort}`}`,
-      `connect-src https://raw.githubusercontent.com/pnp/vscode-viva/dev/data/sp-dev-fx-aces-samples.json https://raw.githubusercontent.com/pnp/vscode-viva/dev/data/sp-dev-fx-aces-scenarios.json https://raw.githubusercontent.com/pnp/vscode-viva/dev/data/sp-dev-fx-extensions-samples.json https://raw.githubusercontent.com/pnp/vscode-viva/dev/data/sp-dev-fx-webparts-samples.json ${isProd ? `` : `ws://localhost:${devPort} ws://0.0.0.0:${devPort} ${localServer}:${devPort} http://0.0.0.0:${devPort}`}`,
+      `connect-src https://raw.githubusercontent.com/pnp/vscode-viva/main/data/sp-dev-fx-aces-samples.json https://raw.githubusercontent.com/pnp/vscode-viva/main/data/sp-dev-fx-aces-scenarios.json https://raw.githubusercontent.com/pnp/vscode-viva/main/data/sp-dev-fx-extensions-samples.json https://raw.githubusercontent.com/pnp/vscode-viva/main/data/sp-dev-fx-webparts-samples.json ${isProd ? `` : `ws://localhost:${devPort} ws://0.0.0.0:${devPort} ${localServer}:${devPort} http://0.0.0.0:${devPort}`}`,
     ];
 
     // Provide additional data attributes for the webview

--- a/src/webview/view/hooks/useSamples.tsx
+++ b/src/webview/view/hooks/useSamples.tsx
@@ -5,7 +5,7 @@ import { Sample } from '../../../models';
 import { GalleryType } from '../components/gallery';
 
 
-const SAMPLES_URL = 'https://raw.githubusercontent.com/pnp/vscode-viva/dev/data/';
+const SAMPLES_URL = 'https://raw.githubusercontent.com/pnp/vscode-viva/main/data/';
 
 // eslint-disable-next-line no-unused-vars
 export default function useSamples(type: GalleryType): [Sample[], ((query: string) => void)] {


### PR DESCRIPTION
## 🎯 Aim

The aim of this PR is to refactor the extension to use local version of CLI for Microsoft365 that was reverted to cjs. Mainly due to the fact es modules are still not supported by VS Code extensions.
Along the way some small bug fixes were included like reading sample data from main branch or allowing to login immediately after logout

## ✅ What was done

- [X] Refactored pipelines to replace npm package with local cleaned-up version of CLI
- [X] Refactored pipelines to use node v18
- [X] Adds new pipeline to create artifact with package
- [X] Bug fix of Login after logout
- [X] Bug fix to read sample data from main
- [X] Adds support for SPFx 1.18.0 (upgrade)
- [x] Validate environment will validate node 16-18
- [x] Update scaffolding process (different flow for node 16 and 18, new ACEs templates)
- [x] Prepare pre-release 

## 🔗 Related issue

Closes: #103 
Closes:  #82 
Closes:  #81