### PR TITLE
Updates yo validation to check for version 4.3.1. Closes: #138

### DIFF
--- a/src/services/Dependencies.ts
+++ b/src/services/Dependencies.ts
@@ -9,7 +9,7 @@ import { Extension } from './Extension';
 
 
 const SUPPORTED_VERSIONS = ['16.13', '18.17.1'];
-const DEPENDENCIES = ['gulp-cli', 'yo', '@microsoft/generator-sharepoint'];
+const DEPENDENCIES = ['gulp-cli', 'yo@4.3.1', '@microsoft/generator-sharepoint'];
 
 export class Dependencies {
 
@@ -59,8 +59,11 @@ export class Dependencies {
             const npmLs: NpmLs = JSON.parse(result.toString());
             const missingDependencies = [];
             for (const dependency of DEPENDENCIES) {
-              const dependencyResult = npmLs.dependencies[dependency];
-              if (!dependencyResult) {
+              const dependencyDetails = Dependencies.splitDependency(dependency);
+              const dependencyVersion = dependencyDetails.length > 1 ? dependencyDetails[1] : null;
+              const dependencyName = dependencyDetails[0];
+              const installedDependency = npmLs.dependencies[dependencyName];
+              if (!installedDependency || (dependencyVersion && installedDependency.version !== dependencyVersion)) {
                 missingDependencies.push(dependency);
               }
             }
@@ -139,5 +142,16 @@ export class Dependencies {
       Logger.error(`Failed checking node version: ${(e as Error).message}`);
       return false;
     }
+  }
+
+  /**
+   * split dependency into name and version
+   */
+  private static splitDependency(dependency: string): string[] {
+    if (dependency.startsWith('@')) {
+      return ['@' + dependency.substring(1).split('@')[0], dependency.substring(1).split('@')[1]];
+    }
+
+    return dependency.split('@');
   }
 }


### PR DESCRIPTION
## 🎯 Aim

The aim is to check for a specific version of yo (4.3.1) and install this one and not the latest one

## 📷 Result

installs the correct version of yo which overwrites any other currently installed version
![image](https://github.com/pnp/vscode-viva/assets/58668583/ea7aad33-2af5-4ce2-be17-c343da8a1aa1)

check for the correct version of yo
![image](https://github.com/pnp/vscode-viva/assets/58668583/5b811f02-b1f4-4d2a-b5a5-982a5d01f010)

![image](https://github.com/pnp/vscode-viva/assets/58668583/3463934e-1217-4f3e-87f1-054957baa9bf)

## ✅ What was done

- [X]  Updated dependency validation

## 🔗 Related issue

Closes: #138