### PR TITLE
Add teams toolkit support. Closes: #131, #133

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,14 @@
 	},
 	"keywords": [
 		"SPFx",
+		"SharePoint Framework",
 		"Viva",
-		"Viva-Connections",
+		"Viva Connections",
 		"Microsoft 365",
 		"SharePoint",
-		"Microsoft Teams"
+		"Microsoft Teams",
+		"Outlook",
+		"Office"
 	],
 	"activationEvents": [
 		"workspaceContains:**/project.pnp",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import { PROJECT_FILE, Scaffolder } from './services/Scaffolder';
 import { Extension } from './services/Extension';
 import { Dependencies } from './services/Dependencies';
 import { unlinkSync, readFileSync } from 'fs';
-import { Terminal } from './services/Terminal';
+import { TerminalCommandExecuter } from './services/TerminalCommandExecuter';
 import { AuthProvider } from './providers/AuthProvider';
 import { CliActions } from './services/CliActions';
 import { ProjectFileContent } from './constants';
@@ -14,7 +14,7 @@ import { ProjectFileContent } from './constants';
 export async function activate(context: ExtensionContext) {
 	Extension.getInstance(context);
 
-	Terminal.register();
+	TerminalCommandExecuter.register();
 
 	AuthProvider.register();
 

--- a/src/models/YoRc.ts
+++ b/src/models/YoRc.ts
@@ -1,0 +1,7 @@
+export interface YoRc {
+  '@microsoft/generator-sharepoint': GeneratorSharePoint;
+}
+
+export interface GeneratorSharePoint {
+  aceTemplateType?: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -6,3 +6,4 @@ export * from './SiteAppCatalog';
 export * from './solution-add-result';
 export * from './subscription';
 export * from './vscode-launch';
+export * from './YoRc';

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -7,6 +7,7 @@ import { CliActions } from '../services/CliActions';
 import { DebuggerCheck } from '../services/DebuggerCheck';
 import { EnvironmentInformation } from '../services/EnvironmentInformation';
 import { TeamsToolkitIntegration } from '../services/TeamsToolkitIntegration';
+import { AdaptiveCardCheck } from '../services/AdaptiveCardCheck';
 
 
 export class CommandPanel {
@@ -51,14 +52,14 @@ export class CommandPanel {
 
     TeamsToolkitIntegration.isTeamsToolkitProject = isTeamsToolkitProject;
 
-    CommandPanel.registerTreeview();
+    CommandPanel.registerTreeView();
     AuthProvider.verify();
   }
 
   /**
    * Register all the treeviews
    */
-  private static registerTreeview() {
+  private static registerTreeView() {
     const authInstance = AuthProvider.getInstance();
     if (authInstance) {
       authInstance.getAccount().then(account => CommandPanel.accountTreeView(account));
@@ -119,6 +120,8 @@ export class CommandPanel {
       const origin = url.origin;
       DebuggerCheck.validateUrl(origin);
 
+      AdaptiveCardCheck.validateACEComponent();
+
       environmentCommands.push(
         new ActionTreeItem('SharePoint', '', { name: 'sharepoint', custom: true }, undefined, undefined, undefined, undefined, [
           new ActionTreeItem(origin, '', { name: 'globe', custom: false }, undefined, 'vscode.open', Uri.parse(origin), 'sp-url')
@@ -137,7 +140,7 @@ export class CommandPanel {
       }
     }
 
-    window.registerTreeDataProvider('pnp-view-environment', new ActionTreeviewProvider(environmentCommands));
+    window.createTreeView('pnp-view-environment', { treeDataProvider: new ActionTreeviewProvider(environmentCommands), showCollapseAll: true });
   }
 
   /**
@@ -183,81 +186,34 @@ export class CommandPanel {
    * Provide the actions for the help treeview
    */
   private static helpTreeView() {
-    const links = [
-      {
-        title: 'Overview of Viva Connections Extensibility',
-        url: 'https://learn.microsoft.com/en-us/sharepoint/dev/spfx/viva/overview-viva-connections',
-        image: { name: 'book', custom: false }
-      },
-      {
-        title: 'Overview of the SharePoint Framework',
-        url: 'https://learn.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview',
-        image: { name: 'book', custom: false }
-      },
-      {
-        title: 'Overview of Microsoft Graph',
-        url: 'https://learn.microsoft.com/en-us/graph/overview?view=graph-rest-1.0',
-        image: { name: 'book', custom: false }
-      },
-      {
-        title: 'Learning path: Extend Microsoft Viva Connections',
-        url: 'https://learn.microsoft.com/en-us/training/paths/m365-extend-viva-connections/',
-        image: { name: 'mortar-board', custom: false }
-      },
-      {
-        title: 'Learning path: Extend Microsoft SharePoint - Associate',
-        url: 'https://learn.microsoft.com/en-us/training/paths/m365-sharepoint-associate/',
-        image: { name: 'mortar-board', custom: false }
-      },
-      {
-        title: 'Learning path: Microsoft Graph Fundamentals',
-        url: 'https://learn.microsoft.com/en-us/training/paths/m365-msgraph-fundamentals/',
-        image: { name: 'mortar-board', custom: false }
-      },
-      {
-        title: 'Sample Solution Gallery',
-        url: 'https://adoption.microsoft.com/en-us/sample-solution-gallery/',
-        image: { name: 'library', custom: false }
-      },
-      {
-        title: 'Adaptive Card Designer',
-        url: 'https://adaptivecards.io/designer/',
-        image: { name: 'globe', custom: false }
-      },
-      {
-        title: 'Microsoft Graph Explorer',
-        url: 'https://developer.microsoft.com/en-us/graph/graph-explorer',
-        image: { name: 'globe', custom: false }
-      },
-      {
-        title: 'Join the Microsoft 365 Developer Program',
-        url: 'https://developer.microsoft.com/en-us/microsoft-365/dev-program',
-        image: { name: 'star-empty', custom: false }
-      },
-      {
-        title: 'Microsoft 365 & Power Platform Community Home',
-        url: 'https://pnp.github.io/',
-        image: { name: 'organization', custom: false }
-      },
-      {
-        title: 'Join the Microsoft 365 & Power Platform Community Discord Server',
-        url: 'https://aka.ms/community/discord',
-        image: { name: 'feedback', custom: false }
-      },
-      {
-        title: 'Wiki',
-        url: 'https://github.com/pnp/vscode-viva/wiki',
-        image: { name: 'question', custom: false }
-      },
-      {
-        title: 'Report an issue',
-        url: 'https://github.com/pnp/vscode-viva/issues/new/choose',
-        image: { name: 'github', custom: false }
-      }
+    const helpCommands: ActionTreeItem[] = [
+      new ActionTreeItem('Docs & Learning', '', undefined, undefined, undefined, undefined, undefined, [
+        new ActionTreeItem('Overview of the SharePoint Framework', '', { name: 'book', custom: false }, undefined, 'vscode.open', Uri.parse('https://learn.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview')),
+        new ActionTreeItem('Overview of Viva Connections Extensibility', '', { name: 'book', custom: false }, undefined, 'vscode.open', Uri.parse('https://learn.microsoft.com/en-us/sharepoint/dev/spfx/viva/overview-viva-connections')),
+        new ActionTreeItem('Overview of Microsoft Graph', '', { name: 'book', custom: false }, undefined, 'vscode.open', Uri.parse('https://learn.microsoft.com/en-us/graph/overview?view=graph-rest-1.0')),
+        new ActionTreeItem('Learning path: Extend Microsoft SharePoint - Associate', '', { name: 'mortar-board', custom: false }, undefined, 'vscode.open', Uri.parse('https://learn.microsoft.com/en-us/training/paths/m365-sharepoint-associate/')),
+        new ActionTreeItem('Learning path: Extend Microsoft Viva Connections', '', { name: 'mortar-board', custom: false }, undefined, 'vscode.open', Uri.parse('https://learn.microsoft.com/en-us/training/paths/m365-extend-viva-connections/')),
+        new ActionTreeItem('Learning path: Microsoft Graph Fundamentals', '', { name: 'mortar-board', custom: false }, undefined, 'vscode.open', Uri.parse('https://learn.microsoft.com/en-us/training/paths/m365-msgraph-fundamentals/'))
+      ]),
+      new ActionTreeItem('Resources & Tooling', '', undefined, undefined, undefined, undefined, undefined, [
+        new ActionTreeItem('Microsoft Graph Explorer', '', { name: 'globe', custom: false }, undefined, 'vscode.open', Uri.parse('https://developer.microsoft.com/en-us/graph/graph-explorer')),
+        new ActionTreeItem('Teams Toolkit', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension')),
+        new ActionTreeItem('Adaptive Card Previewer', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.vscode-adaptive-cards')),
+        new ActionTreeItem('Adaptive Card Designer', '', { name: 'globe', custom: false }, undefined, 'vscode.open', Uri.parse('https://adaptivecards.io/designer/')),
+        new ActionTreeItem('Join the Microsoft 365 Developer Program', '', { name: 'star-empty', custom: false }, undefined, 'vscode.open', Uri.parse('https://developer.microsoft.com/en-us/microsoft-365/dev-program')),
+        new ActionTreeItem('Sample Solution Gallery', '', { name: 'library', custom: false }, undefined, 'vscode.open', Uri.parse('https://adoption.microsoft.com/en-us/sample-solution-gallery/'))
+      ]),
+      new ActionTreeItem('Community', '', undefined, undefined, undefined, undefined, undefined, [
+        new ActionTreeItem('Microsoft 365 & Power Platform Community Home', '', { name: 'organization', custom: false }, undefined, 'vscode.open', Uri.parse('https://pnp.github.io/')),
+        new ActionTreeItem('Join the Microsoft 365 & Power Platform Community Discord Server', '', { name: 'feedback', custom: false }, undefined, 'vscode.open', Uri.parse('https://aka.ms/community/discord'))
+      ]),
+      new ActionTreeItem('Support', '', undefined, undefined, undefined, undefined, undefined, [
+        new ActionTreeItem('Wiki', '', { name: 'question', custom: false }, undefined, 'vscode.open', Uri.parse('https://github.com/pnp/vscode-viva/wiki')),
+        new ActionTreeItem('Report an issue', '', { name: 'github', custom: false }, undefined, 'vscode.open', Uri.parse('https://github.com/pnp/vscode-viva/issues/new/choose'))
+      ])
     ];
 
-    const helpCommands: ActionTreeItem[] = links.map(link => new ActionTreeItem(link.title, '', link.image, undefined, 'vscode.open', Uri.parse(link.url)));
-    window.registerTreeDataProvider('pnp-view-help', new ActionTreeviewProvider(helpCommands));
+    window.createTreeView('pnp-view-help', { treeDataProvider: new ActionTreeviewProvider(helpCommands), showCollapseAll: true });
   }
 
   /**

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -6,6 +6,7 @@ import { AuthProvider, M365AuthenticationSession } from '../providers/AuthProvid
 import { CliActions } from '../services/CliActions';
 import { DebuggerCheck } from '../services/DebuggerCheck';
 import { EnvironmentInformation } from '../services/EnvironmentInformation';
+import { TeamsToolkitIntegration } from '../services/TeamsToolkitIntegration';
 
 
 export class CommandPanel {
@@ -19,7 +20,14 @@ export class CommandPanel {
    * @returns
    */
   private static async init() {
-    const files = await workspace.findFiles('.yo-rc.json', '**/node_modules/**');
+    let isTeamsToolkitProject = false;
+    let files = await workspace.findFiles('.yo-rc.json', '**/node_modules/**');
+
+    if (files.length <= 0) {
+      files = await workspace.findFiles('src/.yo-rc.json', '**/node_modules/**');
+      isTeamsToolkitProject = true;
+    }
+
     if (files.length <= 0) {
       CommandPanel.showWelcome();
       return;
@@ -40,6 +48,8 @@ export class CommandPanel {
 
     commands.executeCommand('setContext', ContextKeys.isSPFxProject, true);
     commands.executeCommand('setContext', ContextKeys.showWelcome, false);
+
+    TeamsToolkitIntegration.isTeamsToolkitProject = isTeamsToolkitProject;
 
     CommandPanel.registerTreeview();
     AuthProvider.verify();

--- a/src/providers/AuthProvider.ts
+++ b/src/providers/AuthProvider.ts
@@ -7,7 +7,7 @@ import { Extension } from './../services/Extension';
 import { executeCommand } from '@pnp/cli-microsoft365';
 import { exec } from 'child_process';
 import { Folders } from '../services/Folders';
-import { Terminal } from '../services/Terminal';
+import { TerminalCommandExecuter } from '../services/TerminalCommandExecuter';
 
 
 export class M365AuthenticationSession implements AuthenticationSession {
@@ -147,7 +147,7 @@ export class AuthProvider implements AuthenticationProvider, Disposable {
 
         // Bring the editor to the front
         const wsFolder = await Folders.getWorkspaceFolder();
-        exec('code .', { cwd: wsFolder?.uri.fsPath, shell: Terminal.shell });
+        exec('code .', { cwd: wsFolder?.uri.fsPath, shell: TerminalCommandExecuter.shell });
 
         this.onDidChangeEventEmit.fire({ added: [account as any], removed: [], changed: [] });
 

--- a/src/services/AdaptiveCardCheck.ts
+++ b/src/services/AdaptiveCardCheck.ts
@@ -1,0 +1,50 @@
+import { extensions, workspace, env, Uri } from 'vscode';
+import { Logger } from './Logger';
+import { YoRc } from '../models';
+import { Notifications } from './Notifications';
+
+
+export class AdaptiveCardCheck {
+  /**
+   * Check if yo-rc has ACE component
+   */
+  public static async validateACEComponent() {
+    try {
+      const vsCodeAdaptiveCardsExtension = extensions.getExtension('TeamsDevApp.vscode-adaptive-cards');
+
+      if (vsCodeAdaptiveCardsExtension) {
+        return;
+      }
+
+      let yoRcFiles = await workspace.findFiles('.yo-rc.json', '**/node_modules/**');
+
+      if (!yoRcFiles || yoRcFiles.length <= 0) {
+        yoRcFiles = await workspace.findFiles('src/.yo-rc.json', '**/node_modules/**');
+      }
+
+      if (!yoRcFiles || yoRcFiles.length <= 0) {
+        return;
+      }
+
+      for (const file of yoRcFiles) {
+        let content: YoRc | string = await workspace.openTextDocument(file.fsPath).then(doc => doc.getText());
+
+        if (!content) {
+          continue;
+        }
+
+        content = typeof content === 'string' ? JSON.parse(content) as YoRc : content;
+
+        if(content && content['@microsoft/generator-sharepoint'] && content['@microsoft/generator-sharepoint'].aceTemplateType) {
+          const answer = await Notifications.info('Consider installing Adaptive Card Previewer to boost your productivity with ACE projects. Would you like to install the extension?', 'yes', 'no');
+
+          if (answer === 'yes') {
+            env.openExternal(Uri.parse('https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.vscode-adaptive-cards'));
+          }
+        }
+      }
+    } catch (e) {
+      Logger.error(`Error validating launch.json: ${e}`);
+    }
+  }
+}

--- a/src/services/CliActions.ts
+++ b/src/services/CliActions.ts
@@ -116,7 +116,13 @@ export class CliActions {
     // Change the current working directory to the root of the Project
     const wsFolder = await Folders.getWorkspaceFolder();
     if (wsFolder) {
-      process.chdir(wsFolder.uri.fsPath);
+      let path = wsFolder.uri.fsPath;
+
+      if (TeamsToolkitIntegration.isTeamsToolkitProject) {
+        path = join(path, 'src');
+      }
+
+      process.chdir(path);
     }
 
     const newName = await window.showInputBox({
@@ -152,7 +158,7 @@ export class CliActions {
     }, async (progress: Progress<{ message?: string; increment?: number }>) => {
       try {
         let result: CommandOutput;
-        if(shouldGenerateNewId) {
+        if (shouldGenerateNewId) {
           result = await CliExecuter.execute('spfx project rename', 'json', { newName: newName, generateNewId: shouldGenerateNewId });
         } else {
           result = await CliExecuter.execute('spfx project rename', 'json', { newName: newName });
@@ -175,7 +181,13 @@ export class CliActions {
     // Change the current working directory to the root of the Project
     const wsFolder = await Folders.getWorkspaceFolder();
     if (wsFolder) {
-      process.chdir(wsFolder.uri.fsPath);
+      let path = wsFolder.uri.fsPath;
+
+      if (TeamsToolkitIntegration.isTeamsToolkitProject) {
+        path = join(path, 'src');
+      }
+
+      process.chdir(path);
     }
 
     await window.withProgress({
@@ -206,7 +218,13 @@ export class CliActions {
     // Change the current working directory to the root of the Project
     const wsFolder = await Folders.getWorkspaceFolder();
     if (wsFolder) {
-      process.chdir(wsFolder.uri.fsPath);
+      let path = wsFolder.uri.fsPath;
+
+      if (TeamsToolkitIntegration.isTeamsToolkitProject) {
+        path = join(path, 'src');
+      }
+
+      process.chdir(path);
     }
 
     const name = await window.showInputBox({
@@ -240,22 +258,31 @@ export class CliActions {
     });
 
     let siteUrl: string | undefined;
-    if (scope === 'sitecollection'){
-      siteUrl = await window.showInputBox({
-        title: 'Specify the URL of the site collection where the solution package will be added',
-        ignoreFocusOut: true,
-        validateInput: async (value) => {
-          if (!value) {
-            return 'Site app catalog url is required';
-          }
+    if (scope === 'sitecollection') {
+      if (EnvironmentInformation.appCatalogUrls && EnvironmentInformation.appCatalogUrls.length > 1) {
+        siteUrl = await window.showQuickPick(EnvironmentInformation.appCatalogUrls.map(url => url, {
+          placeHolder: 'Select the App Catalog',
+          ignoreFocusOut: true,
+          canPickMany: false,
+          title: 'Select the App Catalog'
+        }));
+      } else {
+        siteUrl = await window.showInputBox({
+          title: 'Specify the URL of the site collection where the solution package will be added',
+          ignoreFocusOut: true,
+          validateInput: async (value) => {
+            if (!value) {
+              return 'Site app catalog url is required';
+            }
 
-          if (value.toLowerCase().indexOf('https://') < 0 || value.toLowerCase().indexOf('appcatalog') < 0) {
-            return `${value} is not a valid SharePoint Online site app catalog URL`;
-          }
+            if (value.toLowerCase().indexOf('https://') < 0 || value.toLowerCase().indexOf('appcatalog') < 0) {
+              return `${value} is not a valid SharePoint Online site app catalog URL`;
+            }
 
-          return undefined;
-        }
-      });
+            return undefined;
+          }
+        });
+      }
 
       if (!siteUrl) {
         return;
@@ -337,7 +364,13 @@ export class CliActions {
     // Change the current working directory to the root of the Project
     const wsFolder = await Folders.getWorkspaceFolder();
     if (wsFolder) {
-      process.chdir(wsFolder.uri.fsPath);
+      let path = wsFolder.uri.fsPath;
+
+      if (TeamsToolkitIntegration.isTeamsToolkitProject) {
+        path = join(path, 'src');
+      }
+
+      process.chdir(path);
     }
 
     await window.withProgress({
@@ -351,7 +384,13 @@ export class CliActions {
 
         if (result.stdout) {
           // Create a file to allow the Markdown preview to correctly open the linked/referenced files
-          const filePath = join(wsFolder?.uri.fsPath || '', 'spfx.validate.md');
+          let savePath = wsFolder?.uri.fsPath;
+
+          if (savePath && TeamsToolkitIntegration.isTeamsToolkitProject) {
+            savePath = join(savePath, 'src');
+          }
+
+          const filePath = join(savePath || '', 'spfx.validate.md');
           writeFileSync(filePath, result.stdout);
           await commands.executeCommand('markdown.showPreview', Uri.file(filePath));
         } else if (result.stderr) {

--- a/src/services/CliActions.ts
+++ b/src/services/CliActions.ts
@@ -11,6 +11,7 @@ import { basename, join } from 'path';
 import { EnvironmentInformation } from './EnvironmentInformation';
 import { AuthProvider } from '../providers/AuthProvider';
 import { CommandOutput } from '@pnp/cli-microsoft365';
+import { TeamsToolkitIntegration } from './TeamsToolkitIntegration';
 
 
 export class CliActions {
@@ -69,7 +70,13 @@ export class CliActions {
     // Change the current working directory to the root of the Project
     const wsFolder = await Folders.getWorkspaceFolder();
     if (wsFolder) {
-      process.chdir(wsFolder.uri.fsPath);
+      let path = wsFolder.uri.fsPath;
+
+      if (TeamsToolkitIntegration.isTeamsToolkitProject) {
+        path = join(path, 'src');
+      }
+
+      process.chdir(path);
     }
 
     await window.withProgress({
@@ -83,7 +90,13 @@ export class CliActions {
 
         if (result.stdout) {
           // Create a file to allow the Markdown preview to correctly open the linked/referenced files
-          const filePath = join(wsFolder?.uri.fsPath || '', 'spfx.upgrade.md');
+          let savePath = wsFolder?.uri.fsPath;
+
+          if (savePath && TeamsToolkitIntegration.isTeamsToolkitProject) {
+            savePath = join(savePath, 'src');
+          }
+
+          const filePath = join(savePath || '', 'spfx.upgrade.md');
           writeFileSync(filePath, result.stdout);
           await commands.executeCommand('markdown.showPreview', Uri.file(filePath));
         } else if (result.stderr) {

--- a/src/services/DebuggerCheck.ts
+++ b/src/services/DebuggerCheck.ts
@@ -34,7 +34,11 @@ export class DebuggerCheck {
    * @returns
    */
   private static async validateLaunch(url: string) {
-    const launchFiles = await workspace.findFiles('.vscode/launch.json', '**/node_modules/**');
+    let launchFiles = await workspace.findFiles('.vscode/launch.json', '**/node_modules/**');
+
+    if (!launchFiles || launchFiles.length <= 0) {
+      launchFiles = await workspace.findFiles('src/.vscode/launch.json', '**/node_modules/**');
+    }
 
     if (!launchFiles || launchFiles.length <= 0) {
       return;
@@ -75,7 +79,11 @@ export class DebuggerCheck {
    * @returns
    */
   private static async validateServe(url: string) {
-    const serveFiles = await workspace.findFiles('config/serve.json', '**/node_modules/**');
+    let serveFiles = await workspace.findFiles('config/serve.json', '**/node_modules/**');
+
+    if (!serveFiles || serveFiles.length <= 0) {
+      serveFiles = await workspace.findFiles('src/config/serve.json', '**/node_modules/**');
+    }
 
     if (!serveFiles || serveFiles.length <= 0) {
       return;

--- a/src/services/Dependencies.ts
+++ b/src/services/Dependencies.ts
@@ -4,7 +4,7 @@ import { execSync } from 'child_process';
 import { commands, ProgressLocation, ThemeIcon, window } from 'vscode';
 import { Logger } from './Logger';
 import { NpmLs, Subscription } from '../models';
-import { Terminal } from './Terminal';
+import { TerminalCommandExecuter } from './TerminalCommandExecuter';
 import { Extension } from './Extension';
 
 
@@ -49,7 +49,7 @@ export class Dependencies {
             progress.report({ message: 'Checking npm dependencies...' });
 
             const command = 'npm list -g --json --silent';
-            const result = execSync(command, { shell: Terminal.shell, timeout: 15000 });
+            const result = execSync(command, { shell: TerminalCommandExecuter.shell, timeout: 15000 });
 
             if (!result) {
               Notifications.error('Failed checking dependencies');
@@ -109,12 +109,12 @@ export class Dependencies {
    */
   private static isValidNodeJs() {
     try {
-      const output = execSync('node --version', { shell: Terminal.shell });
+      const output = execSync('node --version', { shell: TerminalCommandExecuter.shell });
       const match = /v(?<major_version>\d+)\.(?<minor_version>\d+)\.(?<patch_version>\d+)/gm.exec(output.toString());
 
       Logger.info(`Node.js version: ${output}`);
 
-      const npmOutput = execSync('npm --version', { shell: Terminal.shell });
+      const npmOutput = execSync('npm --version', { shell: TerminalCommandExecuter.shell });
       Logger.info(`npm version: ${npmOutput}`);
 
       if (!match) {

--- a/src/services/Scaffolder.ts
+++ b/src/services/Scaffolder.ts
@@ -16,6 +16,7 @@ import { CliExecuter } from './CliCommandExecuter';
 import { getPlatform } from '../utils';
 import { TerminalCommandExecuter } from './TerminalCommandExecuter';
 import { execSync } from 'child_process';
+import { TeamsToolkitIntegration } from './TeamsToolkitIntegration';
 
 
 export const PROJECT_FILE = 'project.pnp';
@@ -283,7 +284,13 @@ export class Scaffolder {
       try {
         if (!folderPath) {
           const wsFolder = await Folders.getWorkspaceFolder();
-          folderPath = wsFolder?.uri.fsPath || '';
+          let path = wsFolder?.uri.fsPath;
+
+          if (path && TeamsToolkitIntegration.isTeamsToolkitProject) {
+            path = join(path, 'src');
+          }
+
+          folderPath = path || '';
         }
 
         const result = await Executer.executeCommand(folderPath, yoCommand);

--- a/src/services/Scaffolder.ts
+++ b/src/services/Scaffolder.ts
@@ -14,7 +14,7 @@ import { Extension } from './Extension';
 import download from 'github-directory-downloader/esm';
 import { CliExecuter } from './CliCommandExecuter';
 import { getPlatform } from '../utils';
-import { Terminal } from './Terminal';
+import { TerminalCommandExecuter } from './TerminalCommandExecuter';
 import { execSync } from 'child_process';
 
 
@@ -310,7 +310,7 @@ export class Scaffolder {
    * @returns
    */
   private static async aceComponent(): Promise<{ aceTemplateType: NameValue, componentName: string } | undefined> {
-    const output = execSync('node --version', { shell: Terminal.shell });
+    const output = execSync('node --version', { shell: TerminalCommandExecuter.shell });
     const match = /v(?<major_version>\d+)\.(?<minor_version>\d+)\.(?<patch_version>\d+)/gm.exec(output.toString());
     const nodeVersion = null === match ? '18' : match.groups?.major_version!;
     const adaptiveCardTypes = nodeVersion === '16' ? AdaptiveCardTypesNode16 : AdaptiveCardTypesNode18;

--- a/src/services/TeamsToolkitIntegration.ts
+++ b/src/services/TeamsToolkitIntegration.ts
@@ -1,0 +1,15 @@
+export class TeamsToolkitIntegration {
+  private static _isTeamsToolkitProject: boolean | undefined = undefined;
+
+  public static get isTeamsToolkitProject(): boolean | undefined {
+    return this._isTeamsToolkitProject;
+  }
+
+  public static set isTeamsToolkitProject(value: boolean | undefined) {
+    this._isTeamsToolkitProject = value;
+  }
+
+  public static reset() {
+    this._isTeamsToolkitProject = undefined;
+  }
+}


### PR DESCRIPTION
## 🎯 Aim

The aim of this PR is to modify the extension so it will co-work better with Teams Toolkit.

## 📷 Result

When ACE component is present in the project the extension will suggest to install Adaptive Card Previewer 

![image](https://github.com/pnp/vscode-viva/assets/58668583/9ee1acbd-96f8-4166-94e8-63a11ef17eb4)

Refactored Help & Feedback section to tree view with new Tools section with links to Teams Toolkit and Adaptive Card Previewer

![image](https://github.com/pnp/vscode-viva/assets/58668583/2e484e3f-cfa3-4fee-ba74-89d8c976a801)

Along the way refactored CI/CD action when sitecollection picked it now presents list of site level app catalogs to pick

![image](https://github.com/pnp/vscode-viva/assets/58668583/eb40f562-8bfe-405f-a41b-6e1b9ca7d688)

Refactored all CLI actions to work in sub /src folder like in this example the upgrade action

![image](https://github.com/pnp/vscode-viva/assets/58668583/5119d862-c4bd-4b10-9cd4-491c61018937)

## ✅ What was done

- [X] modified debugger to understand TT project 
- [X] modified all Actions to understand TT project 
- [X] refactored help and feedback section to tree view adding new links to TT and ACE previewer
- [X] added ACE previewer checker to suggest this extension when ACE component is present in the project
- [X] modified project validation not to show welcome screen in TT project with spfx

## 🔗 Related issue

Closes #131
Closes #133