### PR TITLE
Support for NVS (#180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Check it out in action 👇
 
 ### 1️⃣2️⃣ Node.js Version Manager Support
 
-By default, the Viva Connections Toolkit will use the Node.js version that is installed on your machine. If you want to use a different version, you can use a Node.js Version Manager such as [nvm](https://github.com/nvm-sh/nvm) or [nvs](https://github.com/jasongin/nvs). The Viva Connections Toolkit will detect preferred version of Node.js if an `.nvmrc` file is present in the root of your project, and will use that version for all the actions.
+By default, the Viva Connections Toolkit will use the Node.js version that is installed on your machine. If you want to use a different version, you can use a Node.js Version Manager such as [nvm](https://github.com/nvm-sh/nvm) or [nvs](https://github.com/jasongin/nvs). The Viva Connections Toolkit will detect the preferred version of Node.js if a `.nvmrc` file is present in the root of your project, and will use that version for all the actions.
 
 You can use the settings to change which Node.js version manager you want to use. You may choose between `nvm` and `nvs`. If you wish to avoid using a Node.js version manager, you can set the value to `none`
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ Check it out in action 👇
 
 [Check out our docs for more details](https://github.com/pnp/vscode-viva/wiki/6-Teams-Toolkit-Integration)
 
+### 1️⃣2️⃣ Node.js Version Manager Support
+
+By default, the Viva Connections Toolkit will use the Node.js version that is installed on your machine. If you want to use a different version, you can use a Node.js Version Manager such as [nvm](https://github.com/nvm-sh/nvm) or [nvs](https://github.com/jasongin/nvs). The Viva Connections Toolkit will detect preferred version of Node.js if an `.nvmrc` file is present in the root of your project, and will use that version for all the actions.
+
+You can use the settings to change which Node.js version manager you want to use. You may choose between `nvm` and `nvs`. If you wish to avoid using a Node.js version manager, you can set the value to `none`
+
 ## ⚙️ Architecture
 
 Viva Connections Toolkit for Visual Studio Code is an abstraction layer on top of the [SPFx](https://aka.ms/spfx) Yeoman generator and [CLI for Microsoft 365](https://pnp.github.io/cli-microsoft365/). 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "viva-connections-toolkit",
-	"version": "2.6.0",
+	"version": "2.6.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "viva-connections-toolkit",
-			"version": "2.6.0",
+			"version": "2.6.1",
 			"license": "MIT",
 			"dependencies": {
 				"@pnp/cli-microsoft365": "6.11.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,22 @@
 	"license": "MIT",
 	"main": "./dist/extension.js",
 	"contributes": {
+		"configuration": {
+			"title": "Viva Connections Toolkit",
+			"properties": {
+				"viva-connections-toolkit.nodeVersionManager": {
+					"title": "Node.js Version Manager",
+					"type": "string",
+					"default": "nvm",
+					"enum": [
+						"nvm",
+						"nvs",
+						"none"
+					],
+					"description": "Choose your preferred Node.js version manager. Choose between `nvs`, `nvm`, or `none`."
+				}
+			}
+		},
 		"icons": {
 			"spo-m365": {
 				"description": "Microsoft 365 icon",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "viva-connections-toolkit",
 	"displayName": "Viva Connections Toolkit",
 	"description": "Viva Connections Toolkit aims to boost your productivity in developing and managing SharePoint Framework solutions helping at every stage of your development flow, from setting up your development workspace to deploying a solution straight to your tenant without the need to leave VS Code and now even create a CI/CD pipeline to introduce automate deployment of your app. This toolkit is provided by the community.",
-	"version": "2.6.0",
+	"version": "2.6.1",
 	"publisher": "m365pnp",
 	"preview": false,
 	"homepage": "https://github.com/pnp/vscode-viva",

--- a/src/constants/NodeVersionManagers.ts
+++ b/src/constants/NodeVersionManagers.ts
@@ -1,0 +1,7 @@
+/* eslint-disable no-unused-vars */
+// eslint-disable-next-line no-shadow
+export enum NodeVersionManagers {
+    nvm = 'nvm',
+    nvs = 'nvs',
+    none = 'none'
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,6 +5,7 @@ export * from './ContextKeys';
 export * from './ExtensionTypes';
 export * from './FrameworkTypes';
 export * from './General';
+export * from './NodeVersionManagers';
 export * from './ProjectFileContent';
 export * from './WebviewCommand';
 export * from './WebViewTypes';

--- a/src/services/TerminalCommandExecuter.ts
+++ b/src/services/TerminalCommandExecuter.ts
@@ -1,5 +1,5 @@
 import { commands, ThemeIcon, workspace, window, Terminal } from 'vscode';
-import { Commands } from '../constants';
+import { Commands, EXTENSION_NAME, NodeVersionManagers } from '../constants';
 import { Subscription } from '../models';
 import { Extension } from './Extension';
 import { getPlatform } from '../utils';
@@ -88,7 +88,6 @@ export class TerminalCommandExecuter {
         } else {
           terminal.sendText('nvm use');
         }
-      }
       }
     }
 

--- a/src/services/TerminalCommandExecuter.ts
+++ b/src/services/TerminalCommandExecuter.ts
@@ -82,16 +82,13 @@ export class TerminalCommandExecuter {
       const nvmFiles = await workspace.findFiles('.nvmrc', '**/node_modules/**');
 
       // If there are .nvmrc files and the user wants to use nvm, then use their preferred node version manager
-      if (nvmFiles.length > 0 && nodeVersionManager !== 'none') {
-
-        // Launch the command to use the node version specified in the .nvmrc file
-        if (nodeVersionManager === 'nvs') {
-          // Use nvs
+      if (nvmFiles.length > 0 && nodeVersionManager !== NodeVersionManagers.none) {
+        if (nodeVersionManager === NodeVersionManagers.nvs) {
           terminal.sendText('nvs use');
         } else {
-          // Default to nvm
           terminal.sendText('nvm use');
         }
+      }
       }
     }
 

--- a/src/services/TerminalCommandExecuter.ts
+++ b/src/services/TerminalCommandExecuter.ts
@@ -74,14 +74,38 @@ export class TerminalCommandExecuter {
         iconPath: icon ? new ThemeIcon(icon) : undefined
       });
 
+      // Check the user's settings to see if they want to use nvm or nvs
+      // Get the user's preferred node version manager -- nvm or nvs or none, if they don't want to use either
+      const nodeVersionManager: string = TerminalCommandExecuter.getExtensionSettings('nodeVersionManager', 'nvm');
+
       // Check if nvm is used
       const nvmFiles = await workspace.findFiles('.nvmrc', '**/node_modules/**');
-      if (nvmFiles.length > 0) {
-        terminal.sendText('nvm use');
+
+      // If there are .nvmrc files and the user wants to use nvm, then use their preferred node version manager
+      if (nvmFiles.length > 0 && nodeVersionManager !== 'none') {
+
+        // Launch the command to use the node version specified in the .nvmrc file
+        if (nodeVersionManager === 'nvs') {
+          // Use nvs
+          terminal.sendText('nvs use');
+        } else {
+          // Default to nvm
+          terminal.sendText('nvm use');
+        }
       }
     }
 
     return terminal;
+  }
+
+  private static getExtensionSettings<T>(setting: string, defaultValue: T): T {
+    // Replace 'myExtension' with the name of your extension's configuration section
+    const configuration = workspace.getConfiguration('viva-connections-toolkit');
+
+    // Now you can access your settings
+    const extensionSetting = configuration.get<T>(setting, defaultValue);
+
+    return extensionSetting;
   }
 
   private static async runInTerminal(command: string, terminal?: Terminal | undefined) {

--- a/src/services/TerminalCommandExecuter.ts
+++ b/src/services/TerminalCommandExecuter.ts
@@ -96,13 +96,7 @@ export class TerminalCommandExecuter {
   }
 
   private static getExtensionSettings<T>(setting: string, defaultValue: T): T {
-    // Replace 'myExtension' with the name of your extension's configuration section
-    const configuration = workspace.getConfiguration('viva-connections-toolkit');
-
-    // Now you can access your settings
-    const extensionSetting = configuration.get<T>(setting, defaultValue);
-
-    return extensionSetting;
+      return workspace.getConfiguration(EXTENSION_NAME).get<T>(setting, defaultValue);
   }
 
   private static async runInTerminal(command: string, terminal?: Terminal | undefined) {


### PR DESCRIPTION
## 🎯 Aim

Adds support for NVM, NVS, or no Node Version Manager, and a VS Code Setting to control the choice. As discussed with @VesaJuvonen, needed for upcoming SPFx workshops.

## 📷 Result

![image](https://github.com/pnp/vscode-viva/assets/13972467/1e0f7a21-10db-442d-9c6e-7e10fd21cd64)

## ✅ What was done

Added a VSCode setting, and logic to change the command when launching a new terminal.

## 🔗 Related issue

No issues man, we're all good!