### PR TITLE
Updates terminal usage to use TerminalCommandExecuter service. Closes: #246

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,13 +39,11 @@ export async function activate(context: vscode.ExtensionContext) {
 			if (fileContents) {
 				unlinkSync(files[0].fsPath);
 
-				const terminal = window.createTerminal({
-					name: 'Installing dependencies',
-					iconPath: new ThemeIcon('cloud-download')
-				});
+				const terminalTitle = 'Installing dependencies';
+				const terminalIcon = 'cloud-download';
 
 				if (fileContents.indexOf(ProjectFileContent.init) > -1 || fileContents.indexOf(ProjectFileContent.initScenario) > -1) {
-					terminal.sendText('npm i');
+					await TerminalCommandExecuter.runCommand('npm i', [], terminalTitle, terminalIcon);
 				}
 
 				if (fileContents.indexOf(ProjectFileContent.initScenario) > -1) {
@@ -53,18 +51,16 @@ export async function activate(context: vscode.ExtensionContext) {
 				}
 
 				if (fileContents.indexOf(ProjectFileContent.installReusablePropertyPaneControls) > -1) {
-					terminal.sendText('npm install @pnp/spfx-property-controls --save --save-exact');
+					await TerminalCommandExecuter.runCommand('npm install @pnp/spfx-property-controls --save --save-exact', [], terminalTitle, terminalIcon);
 				}
 
 				if (fileContents.indexOf(ProjectFileContent.installReusableReactControls) > -1) {
-					terminal.sendText('npm install @pnp/spfx-controls-react --save --save-exact');
+					await TerminalCommandExecuter.runCommand('npm install @pnp/spfx-controls-react --save --save-exact', [], terminalTitle, terminalIcon);
 				}
 
 				if (fileContents.indexOf(ProjectFileContent.installPnPJs) > -1) {
-					terminal.sendText('npm install @pnp/sp @pnp/graph --save');
+					await TerminalCommandExecuter.runCommand('npm install @pnp/sp @pnp/graph --save', [], terminalTitle, terminalIcon);
 				}
-
-				terminal.show(true);
 			}
 		}
 	});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import { PnPWebview } from './webview/PnPWebview';
 import { CommandPanel } from './panels/CommandPanel';
 import * as vscode from 'vscode';
-import { workspace, window, ThemeIcon, commands } from 'vscode';
+import { workspace, commands } from 'vscode';
 import { PROJECT_FILE, Scaffolder } from './services/Scaffolder';
 import { Extension } from './services/Extension';
 import { Dependencies } from './services/Dependencies';

--- a/src/services/Dependencies.ts
+++ b/src/services/Dependencies.ts
@@ -94,16 +94,8 @@ export class Dependencies {
   /**
    * Installs the dependencies by running the npm install command in a terminal.
    */
-  public static install() {
-    const terminal = window.createTerminal({
-      name: 'Installing dependencies',
-      iconPath: new ThemeIcon('cloud-download')
-    });
-
-    if (terminal) {
-      terminal.sendText(`npm i -g ${DEPENDENCIES.join(' ')}`);
-      terminal.show(true);
-    }
+  public static async install() {
+    await TerminalCommandExecuter.runCommand(`npm i -g ${DEPENDENCIES.join(' ')}`, [], 'Installing dependencies', 'cloud-download');
   }
 
   /**

--- a/src/services/Dependencies.ts
+++ b/src/services/Dependencies.ts
@@ -1,7 +1,7 @@
 import { Commands } from './../constants/Commands';
 import { Notifications } from './Notifications';
 import { execSync } from 'child_process';
-import { commands, ProgressLocation, ThemeIcon, window } from 'vscode';
+import { commands, ProgressLocation, window } from 'vscode';
 import { Logger } from './Logger';
 import { NpmLs, Subscription } from '../models';
 import { TerminalCommandExecuter } from './TerminalCommandExecuter';

--- a/src/services/TerminalCommandExecuter.ts
+++ b/src/services/TerminalCommandExecuter.ts
@@ -145,8 +145,8 @@ export class TerminalCommandExecuter {
    * @param command - The command to run.
    * @param args - The arguments for the command.
    */
-  public static async runCommand(command: string, args: string[]) {
-    const terminal = await TerminalCommandExecuter.createTerminal('Gulp task', 'tasks-list-configure');
+  public static async runCommand(command: string, args: string[], terminalTitle: string = 'Gulp task', terminalIcon: string = 'tasks-list-configure') {
+    const terminal = await TerminalCommandExecuter.createTerminal(terminalTitle, terminalIcon);
 
     const wsFolder = await Folders.getWorkspaceFolder();
     if (wsFolder) {


### PR DESCRIPTION
## 🎯 Aim

The aim is to refactor the way start and run commands in integrated VS Code terminal. The idea is to aling the approach by using the dedicated Terminal service which was developed for exactly that.

## ✅ What was done

- [X] Removes all direct usage of `terminal` and refactors it to same approach

## 🔗 Related issue

Closes: #246