### PR TITLE
Hide toolkit features that require signed in. Closes:  #263

### DIFF
--- a/src/chat/PromptHandlers.ts
+++ b/src/chat/PromptHandlers.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { Commands, promptCodeContext, promptContext, promptNewContext, promptSetupContext } from '../constants';
+import { ProjectInformation } from '../services/dataType/ProjectInformation';
 
 const MODEL_SELECTOR: vscode.LanguageModelChatSelector = { vendor: 'copilot', family: 'gpt-4' };
 
@@ -54,23 +55,26 @@ export class PromptHandlers {
           title: vscode.l10n.t('View samples'),
         }];
       case 'code':
-        // TODO: make visible only in context of a project
-        return [{
-          command: Commands.upgradeProject,
-          title: vscode.l10n.t('Get upgrade guidance to latest SPFx version'),
-        },
-        {
-          command: Commands.validateProject,
-          title: vscode.l10n.t('Validate your project'),
-        },
-        {
-          command: Commands.renameProject,
-          title: vscode.l10n.t('Rename your project'),
-        },
-        {
-          command: Commands.pipeline,
-          title: vscode.l10n.t('Create a CI/CD workflow'),
-        }];
+        if(ProjectInformation.isSPFxProject) {
+          return [{
+            command: Commands.upgradeProject,
+            title: vscode.l10n.t('Get upgrade guidance to latest SPFx version'),
+          },
+          {
+            command: Commands.validateProject,
+            title: vscode.l10n.t('Validate your project'),
+          },
+          {
+            command: Commands.renameProject,
+            title: vscode.l10n.t('Rename your project'),
+          },
+          {
+            command: Commands.pipeline,
+            title: vscode.l10n.t('Create a CI/CD workflow'),
+          }];
+        }
+
+        return [];
       default:
         return [];
     }

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -7,6 +7,7 @@ import { CliActions } from '../services/actions/CliActions';
 import { DebuggerCheck } from '../services/check/DebuggerCheck';
 import { EnvironmentInformation } from '../services/dataType/EnvironmentInformation';
 import { TeamsToolkitIntegration } from '../services/dataType/TeamsToolkitIntegration';
+import { ProjectInformation } from '../services/dataType/ProjectInformation';
 import { AdaptiveCardCheck } from '../services/check/AdaptiveCardCheck';
 import { Subscription } from '../models';
 import { Extension } from '../services/dataType/Extension';
@@ -64,6 +65,7 @@ export class CommandPanel {
       commands.executeCommand('setContext', ContextKeys.isSPFxProject, true);
       commands.executeCommand('setContext', ContextKeys.showWelcome, false);
 
+      ProjectInformation.isSPFxProject = true;
       TeamsToolkitIntegration.isTeamsToolkitProject = isTeamsToolkitProject;
 
       AdaptiveCardCheck.validateACEComponent();
@@ -90,7 +92,6 @@ export class CommandPanel {
     }
 
     CommandPanel.taskTreeView();
-    CommandPanel.actionsTreeView();
     CommandPanel.helpTreeView();
   }
 
@@ -151,6 +152,7 @@ export class CommandPanel {
       accountCommands.push(new ActionTreeItem('Sign in to Microsoft 365', '', { name: 'sign-in', custom: false }, undefined, Commands.login));
     }
 
+    CommandPanel.actionsTreeView();
     window.createTreeView('pnp-view-account', { treeDataProvider: new ActionTreeDataProvider(accountCommands), showCollapseAll: true });
   }
 
@@ -224,16 +226,19 @@ export class CommandPanel {
   }
 
   private static async actionsTreeView() {
-    const actionCommands: ActionTreeItem[] = [
-      new ActionTreeItem('Upgrade project', '', { name: 'arrow-up', custom: false }, undefined, Commands.upgradeProject),
-      new ActionTreeItem('Validate project', '', { name: 'check-all', custom: false }, undefined, Commands.validateProject),
-      new ActionTreeItem('Rename project', '', { name: 'whole-word', custom: false }, undefined, Commands.renameProject),
-      new ActionTreeItem('Grant API permissions', '', { name: 'workspace-trusted', custom: false }, undefined, Commands.grantAPIPermissions),
-      new ActionTreeItem('Deploy project (sppkg)', '', { name: 'cloud-upload', custom: false }, undefined, Commands.deployProject),
-      new ActionTreeItem('Add new component', '', { name: 'add', custom: false }, undefined, Commands.addToProject),
-      new ActionTreeItem('CI/CD Workflow', '', { name: 'rocket', custom: false }, undefined, Commands.pipeline),
-      new ActionTreeItem('View samples', '', { name: 'library', custom: false }, undefined, Commands.samplesGallery),
-    ];
+    const actionCommands: ActionTreeItem[] = [];
+    actionCommands.push(new ActionTreeItem('Upgrade project', '', { name: 'arrow-up', custom: false }, undefined, Commands.upgradeProject));
+    actionCommands.push(new ActionTreeItem('Validate project', '', { name: 'check-all', custom: false }, undefined, Commands.validateProject));
+    actionCommands.push(new ActionTreeItem('Rename project', '', { name: 'whole-word', custom: false }, undefined, Commands.renameProject));
+
+    if(EnvironmentInformation.account) {
+      actionCommands.push(new ActionTreeItem('Grant API permissions', '', { name: 'workspace-trusted', custom: false }, undefined, Commands.grantAPIPermissions));
+      actionCommands.push(new ActionTreeItem('Deploy project (sppkg)', '', { name: 'cloud-upload', custom: false }, undefined, Commands.deployProject));
+    }
+
+    actionCommands.push(new ActionTreeItem('Add new component', '', { name: 'add', custom: false }, undefined, Commands.addToProject));
+    actionCommands.push(new ActionTreeItem('CI/CD Workflow', '', { name: 'rocket', custom: false }, undefined, Commands.pipeline));
+    actionCommands.push(new ActionTreeItem('View samples', '', { name: 'library', custom: false }, undefined, Commands.samplesGallery));
 
     window.registerTreeDataProvider('pnp-view-actions', new ActionTreeDataProvider(actionCommands));
   }

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -231,7 +231,7 @@ export class CommandPanel {
     actionCommands.push(new ActionTreeItem('Validate project', '', { name: 'check-all', custom: false }, undefined, Commands.validateProject));
     actionCommands.push(new ActionTreeItem('Rename project', '', { name: 'whole-word', custom: false }, undefined, Commands.renameProject));
 
-    if(EnvironmentInformation.account) {
+    if (EnvironmentInformation.account) {
       actionCommands.push(new ActionTreeItem('Grant API permissions', '', { name: 'workspace-trusted', custom: false }, undefined, Commands.grantAPIPermissions));
       actionCommands.push(new ActionTreeItem('Deploy project (sppkg)', '', { name: 'cloud-upload', custom: false }, undefined, Commands.deployProject));
     }

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -374,7 +374,7 @@ export class CliActions {
     const account = await authInstance.getAccount();
 
     if (!account) {
-      Notifications.error('You must be logged in to deploy a project.');
+      Notifications.error('You must be logged in to grant API permission for a project.');
       return;
     }
 

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -370,6 +370,14 @@ export class CliActions {
    * @returns A promise that resolves when the API permissions are granted.
    */
   private static async grantAPIPermissions() {
+    const authInstance = AuthProvider.getInstance();
+    const account = await authInstance.getAccount();
+
+    if (!account) {
+      Notifications.error('You must be logged in to deploy a project.');
+      return;
+    }
+
     // Change the current working directory to the root of the Project
     const wsFolder = await Folders.getWorkspaceFolder();
     if (wsFolder) {
@@ -411,7 +419,8 @@ export class CliActions {
     const content = await parseYoRc();
     const data = {
       spfxPackageName: content ? content['@microsoft/generator-sharepoint'].solutionName : '',
-      appCatalogUrls: EnvironmentInformation.appCatalogUrls && EnvironmentInformation.appCatalogUrls.length > 1 ? EnvironmentInformation.appCatalogUrls : []
+      appCatalogUrls: EnvironmentInformation.appCatalogUrls && EnvironmentInformation.appCatalogUrls.length > 1 ? EnvironmentInformation.appCatalogUrls : [],
+      isSignedIn: EnvironmentInformation.account ? true : false
     };
 
     PnPWebview.open(WebViewType.workflowForm, data);

--- a/src/services/dataType/ProjectInformation.ts
+++ b/src/services/dataType/ProjectInformation.ts
@@ -1,0 +1,15 @@
+export class ProjectInformation {
+  private static _isSPFxProject: boolean | undefined = undefined;
+
+  public static get isSPFxProject(): boolean | undefined {
+    return this._isSPFxProject;
+  }
+
+  public static set isSPFxProject(value: boolean | undefined) {
+    this._isSPFxProject = value;
+  }
+
+  public static reset() {
+    this._isSPFxProject = undefined;
+  }
+}

--- a/src/webview/PnPWebview.ts
+++ b/src/webview/PnPWebview.ts
@@ -53,6 +53,10 @@ export class PnPWebview {
         messageData.spfxPackageName = data.spfxPackageName;
       }
 
+      if (data && data.isSignedIn) {
+        messageData.isSignedIn = data.isSignedIn;
+      }
+
       if (data && data.appCatalogUrls) {
         messageData.appCatalogUrls = data.appCatalogUrls;
       }
@@ -94,6 +98,10 @@ export class PnPWebview {
 
     if (data && data.spfxPackageName) {
       webViewData.spfxPackageName = data['spfxPackageName'];
+    }
+
+    if (data && data.isSignedIn) {
+      webViewData.isSignedIn = data.isSignedIn;
     }
 
     if (data && data.appCatalogUrls) {

--- a/src/webview/view/components/forms/workflow/ScaffoldWorkflowView.tsx
+++ b/src/webview/view/components/forms/workflow/ScaffoldWorkflowView.tsx
@@ -24,6 +24,7 @@ export const ScaffoldWorkflowView: React.FunctionComponent<IScaffoldWorkflowView
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [isWorkflowCreated, setIsWorkflowCreated] = useState<boolean>(false);
   const [shouldCreateAppRegistrationForm, setShouldCreateAppRegistrationForm] = useState<boolean>(false);
+  const [isSignedIn, setIsSignedIn] = useState<boolean>(false);
   const [certPassword, setCertPassword] = useState<string>('');
   const [appRegistrationName, setAppRegistrationName] = useState<string>('CI/CD Application');
   const [appId, setAppId] = useState<string>('');
@@ -36,6 +37,10 @@ export const ScaffoldWorkflowView: React.FunctionComponent<IScaffoldWorkflowView
     if (location.state.spfxPackageName) {
       setName(`Deploy Solution ${location.state.spfxPackageName}`);
       setAppRegistrationName(`CI/CD Application for ${location.state.spfxPackageName}`);
+    }
+
+    if (location.state.isSignedIn) {
+      setIsSignedIn(location.state.isSignedIn);
     }
 
     if (location.state.appCatalogUrls) {
@@ -219,12 +224,14 @@ export const ScaffoldWorkflowView: React.FunctionComponent<IScaffoldWorkflowView
                       </>
                   }
                   <div>
-                    <div className={'mt-2'}>
-                      <p className={'mb-1'}><strong>Don't have an app registration yet?</strong></p>
-                      <p className={'mb-2'}>👇 No problem, generate all that you need for your {workflowType === WorkflowType.gitHub ? 'workflow' : 'pipeline'} 👇</p>
-                      <VSCodeCheckbox checked={shouldCreateAppRegistrationForm} onChange={() => setShouldCreateAppRegistrationForm(!shouldCreateAppRegistrationForm)}>
-                        Generate a certificate and create an app registration
-                      </VSCodeCheckbox>
+                    <div className={isSignedIn ? '' : 'hidden'}>
+                      <div className={'mt-2'}>
+                        <p className={'mb-1'}><strong>Don't have an app registration yet?</strong></p>
+                        <p className={'mb-2'}>👇 No problem, generate all that you need for your {workflowType === WorkflowType.gitHub ? 'workflow' : 'pipeline'} 👇</p>
+                        <VSCodeCheckbox checked={shouldCreateAppRegistrationForm} onChange={() => setShouldCreateAppRegistrationForm(!shouldCreateAppRegistrationForm)}>
+                          Generate a certificate and create an app registration
+                        </VSCodeCheckbox>
+                      </div>
                     </div>
                     <div className={shouldCreateAppRegistrationForm ? '' : 'hidden'}>
                       <p className={'mt-1 mb-1'}>Here you may generate a new certificate and register a new app registration with a single click 🤩</p>

--- a/src/webview/view/index.tsx
+++ b/src/webview/view/index.tsx
@@ -19,6 +19,7 @@ if (elm) {
 
   const homePageUrl = elm.getAttribute('data-homePageUrl');
   const spfxPackageName = elm.getAttribute('data-spfxPackageName');
+  const isSignedIn = elm.getAttribute('data-isSignedIn');
   const appCatalogUrls = elm.getAttribute('data-appCatalogUrls');
   const type = elm.getAttribute('data-type');
   const isNewProject = elm.getAttribute('data-isNewProject');
@@ -26,6 +27,10 @@ if (elm) {
 
   if (spfxPackageName) {
     data.spfxPackageName = spfxPackageName;
+  }
+
+  if (isSignedIn) {
+    data.isSignedIn = isSignedIn;
   }
 
   if (appCatalogUrls) {


### PR DESCRIPTION
## 🎯 Aim

The aim is to hide actions that require being signed in and validate if SPFx project in chat actions

## 📷 Result

// TODO

## ✅ What was done

- [X] Adds check if signed it
- [X] Adds check if SPFx project

## 🔗 Related issue

Closes:  #263