### PR TITLE
feat: :sparkles: Include m365 prefix and log passed CLI command options

### DIFF
--- a/src/services/executeWrappers/CliCommandExecuter.ts
+++ b/src/services/executeWrappers/CliCommandExecuter.ts
@@ -28,8 +28,20 @@ export class CliExecuter {
       let cmdOutput: string = '';
       let cmdOutputIncludingStderr: string = '';
       const outputChannel = Logger.channel;
+      let cliCommandOptions = '';
+      if (args) {
+        cliCommandOptions = `${Object.keys(args).map(key => {
+          let option = `--${key}`;
+          const value = args[key];
+          if (value) {
+            option = `${option} ${value}`;
+          }
 
-      Logger.info(`Running CLI command: ${command}`);
+          return option;
+        }).join(' ')}`;
+      }
+
+      Logger.info(`Running CLI command: m365 ${command} --output ${output} ${cliCommandOptions}`);
       executeCommand(command, { output, ...args }, {
         stdout: (message: string) => {
           message = message.toString();


### PR DESCRIPTION
## 🎯 Aim

Adding the m365 prefix: The m365 prefix is now included before every CLI command, ensuring that the logged commands accurately reflect what is run in the terminal.

Logging CLI command options: The PR also includes the functionality to log the options passed with each command, providing better transparency and guidance for developers who want to understand the equivalent terminal commands for SPFx Toolkit features.

However, the functionality to set json as the default output for all commands was not implemented, as there are parts of the code that use other output formats, such as md (Markdown). Changing the default output to json globally could break those functionalities.

![image](https://github.com/user-attachments/assets/61a93e6a-712f-4122-82fb-f00ae3ce18b7)


## 📷 Result

![Captura de tela 2024-09-30 124116](https://github.com/user-attachments/assets/0dce5b35-2022-4e54-980a-4c318441282f)

![Captura de tela 2024-09-30 124152](https://github.com/user-attachments/assets/eb01d647-8580-4677-912a-ea6af1ae10d2)


## ✅ What was done

- [] not done
- [X] done

## 🔗 Related issue


Closes: #283