### PR TITLE
Added tour response for Upgrade and Validate actions, Closes #188

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,6 +210,28 @@
 						".node-version"
 					],
 					"description": "The file to be used to store the Node version for the selected Node version manager. Remember that the .node-version file is supported only while using nvs."
+				},
+				"spfx-toolkit.projectUpgradeOutputMode": {
+					"title": "Project upgrade output mode",
+					"type": "string",
+					"default": "both",
+					"enum": [
+						"both",
+						"markdown",
+						"code tour"
+					],
+					"description": "Choose the output mode for the project upgrade. You can choose between `both`, `markdown`, or `code tour`."
+				},
+				"spfx-toolkit.projectValidateOutputMode": {
+					"title": "Project validate output mode",
+					"type": "string",
+					"default": "both",
+					"enum": [
+						"both",
+						"markdown",
+						"code tour"
+					],
+					"description": "Choose the output mode for the project validation. You can choose between `both`, `markdown`, or `code tour`."
 				}
 			}
 		},

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -505,17 +505,13 @@ export class CliActions {
         const projectUpgradeOutputMode: string = getExtensionSettings('projectUpgradeOutputMode', 'both');
         let resultMd: any;
 
-        if (projectUpgradeOutputMode === 'markdown') {
+        if (projectUpgradeOutputMode === 'markdown' || projectUpgradeOutputMode === 'both') {
           resultMd = await CliExecuter.execute('spfx project upgrade', 'md');
           CliActions.handleMarkdownResult(resultMd, wsFolder, 'upgrade');
-        } else if (projectUpgradeOutputMode === 'code tour') {
+        } 
+        
+        if (projectUpgradeOutputMode === 'code tour' || projectUpgradeOutputMode === 'both') {
           await CliExecuter.execute('spfx project upgrade', 'tour');
-          CliActions.handleTourResult(wsFolder, 'upgrade');
-        } else {
-          resultMd = await CliExecuter.execute('spfx project upgrade', 'md');
-          await CliExecuter.execute('spfx project upgrade', 'tour');
-
-          CliActions.handleMarkdownResult(resultMd, wsFolder, 'upgrade');
           CliActions.handleTourResult(wsFolder, 'upgrade');
         }
       } catch (e: any) {
@@ -844,11 +840,15 @@ export class CliActions {
     }
     
     const tourFilePath = path.join(wsFolder.uri.fsPath, '.tours', `${fileName}.tour`);
-    
+    await workspace.fs.stat(Uri.file(tourFilePath));
+
+    // A timeout is needed so Codetour can find the tour file
     if (fs.existsSync(tourFilePath)) {
-      await commands.executeCommand('codetour.startTour');
+      setTimeout(() => {
+        commands.executeCommand('codetour.startTour');
+      }, 500);
     } else {
-      Notifications.error('Validation tour file not found. Cannot start Code Tour.');
+      Notifications.error(`${fileName}.tour file not found in path ${path.join(wsFolder.uri.fsPath, '.tours')}. Cannot start Code Tour.`);
     }
   }
 }


### PR DESCRIPTION
## 🎯 Aim

Adding the tour options and both md & tour options as settings for the upgrade and validate actions

## 📷 Result

![image](https://github.com/user-attachments/assets/582ac622-aa94-43f5-a3ae-644d24d36f17)

## ✅ What was done

- [X] Added `Md`, `Tour`, `Both` as upgrade options in the settings 
- [X] Added `Md`, `Tour`, `Both` as validate options in the settings 
- [X] Added tour logic to code for the upgrade option
- [X] Added tour logic to code for the validate option

## 🔗 Related issue

Closes: #188