### PR TITLE
Prompts for confirmation before removing an app from app catalog. 

### DIFF
--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -192,6 +192,18 @@ export class CliActions {
 
       const [appID, appTitle, appCatalogUrl] = actionNode.command.arguments;
 
+      const shouldRemove = await window.showQuickPick(['Yes', 'No'], {
+        title: `Are you sure you want to remove the app '${appTitle}' from the app catalog?`,
+        ignoreFocusOut: true,
+        canPickMany: false
+      });
+
+      const shouldRemoveAnswer = shouldRemove === 'Yes';
+
+      if (!shouldRemoveAnswer) {
+        return;
+      }
+
       const commandOptions: any = {
         id: appID,
         force: true,


### PR DESCRIPTION
## 🎯 Aim

> Prompts for a confirmation before removing an app from the app catalog to prevent accidental removals and improve user experience.

## 📷 Result

> ![image](https://github.com/user-attachments/assets/967a48f7-a73c-457e-8dd1-6f61917b915b)

## ✅ What was done

- [X] Updated `removeAppCatalogApp` function to check the user's response and proceed with removal only if confirmed.

## 🔗 Related issue

> Closes: #349