### PR TITLE
Upgrades an app to the latest version available in the app catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ After successful sign in, an additional view is presented that shows a list of l
 - **Remove**: Removes the app from the app catalog.
 - **Enable**: Allows end users to add the solution to their SharePoint sites.
 - **Disable**: Hides the solution from end users, preventing them from adding it to sites.
+- **Upgrade**: Upgrades the solution to the latest version available in the app catalog for the specified site.
 
 Additionally, it will show you all tenant-wide extensions installed on your tenant.
 

--- a/assets/walkthrough/tenant-details.md
+++ b/assets/walkthrough/tenant-details.md
@@ -29,6 +29,7 @@ After successful sign in, an additional view is presented that shows a list of l
 - **Remove**: Removes the app from the app catalog.
 - **Enable**: Allows end users to add the solution to their SharePoint sites.
 - **Disable**: Hides the solution from end users, preventing them from adding it to sites.
+- **Upgrade**: Upgrades the solution to the latest version available in the app catalog for the specified site.
 
 Additionally, it will show you all tenant-wide extensions installed on your tenant.
 

--- a/package.json
+++ b/package.json
@@ -461,6 +461,12 @@
 				"icon": "$(circle-slash)"
 			},
 			{
+				"command": "spfx-toolkit.upgradeAppCatalogApp",
+				"title": "Upgrade",
+				"category": "SharePoint Framework Toolkit",
+				"icon": "$(sync)"
+			},
+			{
 				"command": "spfx-toolkit.showMoreActions",
 				"title": "...",
 				"category": "SharePoint Framework Toolkit",
@@ -531,6 +537,10 @@
 				{
 					"command": "spfx-toolkit.disableAppCatalogApp",
 					"group": "actions.more@4"
+				},
+				{
+					"command": "spfx-toolkit.upgradeAppCatalogApp",
+					"group": "actions.more@5"
 				}
 			],
 			"explorer/context": [

--- a/src/constants/Commands.ts
+++ b/src/constants/Commands.ts
@@ -59,5 +59,6 @@ export const Commands = {
   removeAppCatalogApp: `${EXTENSION_NAME}.removeAppCatalogApp`,
   enableAppCatalogApp: `${EXTENSION_NAME}.enableAppCatalogApp`,
   disableAppCatalogApp: `${EXTENSION_NAME}.disableAppCatalogApp`,
+  upgradeAppCatalogApp: `${EXTENSION_NAME}.upgradeAppCatalogApp`,
   showMoreActions: `${EXTENSION_NAME}.showMoreActions`
 };

--- a/src/constants/ContextKeys.ts
+++ b/src/constants/ContextKeys.ts
@@ -8,5 +8,6 @@ export const ContextKeys = {
   retractApp: 'pnp.etv.app.retract',
   removeApp: 'pnp.etv.app.remove',
   enableApp: 'pnp.etv.app.enable',
-  disableApp: 'pnp.etv.app.disable'
+  disableApp: 'pnp.etv.app.disable',
+  upgradeApp: 'pnp.etv.app.upgrade'
 };

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -211,7 +211,8 @@ export class CommandPanel {
                     new ActionTreeItem('Retract', '', undefined, undefined, Commands.retractAppCatalogApp, [app.ID, app.Title, undefined, app.Deployed], ContextKeys.retractApp),
                     new ActionTreeItem('Remove', '', undefined, undefined, Commands.removeAppCatalogApp, [app.ID, app.Title], ContextKeys.removeApp),
                     new ActionTreeItem('Enable', '', undefined, undefined, Commands.enableAppCatalogApp, [app.Title, tenantAppCatalogUrl, app.Enabled], ContextKeys.enableApp),
-                    new ActionTreeItem('Disable', '', undefined, undefined, Commands.disableAppCatalogApp, [app.Title, tenantAppCatalogUrl, app.Enabled], ContextKeys.disableApp)
+                    new ActionTreeItem('Disable', '', undefined, undefined, Commands.disableAppCatalogApp, [app.Title, tenantAppCatalogUrl, app.Enabled], ContextKeys.disableApp),
+                    new ActionTreeItem('Upgrade', '', undefined, undefined, Commands.upgradeAppCatalogApp, [app.ID, app.Title], ContextKeys.upgradeApp)
                   ]
                 )
               );
@@ -250,7 +251,8 @@ export class CommandPanel {
                       new ActionTreeItem('Retract', '', undefined, undefined, Commands.retractAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, app.Deployed], ContextKeys.retractApp),
                       new ActionTreeItem('Remove', '', undefined, undefined, Commands.removeAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl], ContextKeys.removeApp),
                       new ActionTreeItem('Enable', '', undefined, undefined, Commands.enableAppCatalogApp, [app.Title, siteAppCatalogUrl, app.Enabled], ContextKeys.enableApp),
-                      new ActionTreeItem('Disable', '', undefined, undefined, Commands.disableAppCatalogApp, [app.Title, siteAppCatalogUrl, app.Enabled], ContextKeys.disableApp)
+                      new ActionTreeItem('Disable', '', undefined, undefined, Commands.disableAppCatalogApp, [app.Title, siteAppCatalogUrl, app.Enabled], ContextKeys.disableApp),
+                      new ActionTreeItem('Upgrade', '', undefined, undefined, Commands.upgradeAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl], ContextKeys.upgradeApp)
                     ]
                   )
                 );

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -234,7 +234,7 @@ export class CliActions {
   */
   public static async upgradeAppCatalogApp(node: ActionTreeItem) {
     try {
-      const actionNode = node.children?.find(child => child.contextValue === ContextKeys.removeApp);
+      const actionNode = node.children?.find(child => child.contextValue === ContextKeys.upgradeApp);
 
       if (!actionNode?.command?.arguments) {
         Notifications.error('Failed to retrieve app details for upgrade.');


### PR DESCRIPTION
## 🎯 Aim

> Upgrades an app to the latest version available in the app catalog for the specified site

## 📷 Result

> ![image](https://github.com/user-attachments/assets/3c9255b0-28de-4365-9bce-d12452c611be)


## ✅ What was done

- [X] New action to upgrade an app in the specified site.
- [X]  Prompt for the site URL only when upgrading tenant app catalog apps. For site collection app catalog apps, it uses the site collection app catalog URL and scope.

## 🔗 Related issue

> Closes: #351