### PR TITLE
Improves upgrade app action. Closes #359

### DIFF
--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -212,7 +212,7 @@ export class CommandPanel {
                     new ActionTreeItem('Remove', '', undefined, undefined, Commands.removeAppCatalogApp, [app.ID, app.Title], ContextKeys.removeApp),
                     new ActionTreeItem('Enable', '', undefined, undefined, Commands.enableAppCatalogApp, [app.Title, tenantAppCatalogUrl, app.Enabled], ContextKeys.enableApp),
                     new ActionTreeItem('Disable', '', undefined, undefined, Commands.disableAppCatalogApp, [app.Title, tenantAppCatalogUrl, app.Enabled], ContextKeys.disableApp),
-                    new ActionTreeItem('Upgrade', '', undefined, undefined, Commands.upgradeAppCatalogApp, [app.ID, app.Title], ContextKeys.upgradeApp)
+                    new ActionTreeItem('Upgrade', '', undefined, undefined, Commands.upgradeAppCatalogApp, [app.ID, app.Title, tenantAppCatalogUrl, true], ContextKeys.upgradeApp)
                   ]
                 )
               );
@@ -252,7 +252,7 @@ export class CommandPanel {
                       new ActionTreeItem('Remove', '', undefined, undefined, Commands.removeAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl], ContextKeys.removeApp),
                       new ActionTreeItem('Enable', '', undefined, undefined, Commands.enableAppCatalogApp, [app.Title, siteAppCatalogUrl, app.Enabled], ContextKeys.enableApp),
                       new ActionTreeItem('Disable', '', undefined, undefined, Commands.disableAppCatalogApp, [app.Title, siteAppCatalogUrl, app.Enabled], ContextKeys.disableApp),
-                      new ActionTreeItem('Upgrade', '', undefined, undefined, Commands.upgradeAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl], ContextKeys.upgradeApp)
+                      new ActionTreeItem('Upgrade', '', undefined, undefined, Commands.upgradeAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, false], ContextKeys.upgradeApp)
                     ]
                   )
                 );


### PR DESCRIPTION
## 🎯 Aim

> Improves upgrade app action by allowing users to specify only the relative path and then concatenate it under the hood with the tenant URL

## 📷 Result

> ![image](https://github.com/user-attachments/assets/6699f07d-ce5c-45d0-bfaf-5dd26e744bac)

## ✅ What was done

- [X] Prompt for the relative site URL when upgrading tenant app catalog apps. Concatenate the same under the hood with the tenant URL.

## 🔗 Related issue

Closes: #359