### PR TITLE
Updates /manage chat command to use text output mode for list CLI for M365 commands. Closes: #375

### DIFF
--- a/src/chat/PromptHandlers.ts
+++ b/src/chat/PromptHandlers.ts
@@ -90,7 +90,8 @@ export class PromptHandlers {
     const cliMatch = cliRegex.exec(chatResponse);
 
     if (cliMatch && cliMatch[2]) {
-      const result = await CliActions.runCliCommand(cliMatch[2], 'md');
+      const outputMode = cliMatch[2].toLowerCase().includes('list') ? 'text' : 'md';
+      const result = await CliActions.runCliCommand(cliMatch[2], outputMode);
       return result;
     }
 

--- a/src/constants/Prompts.ts
+++ b/src/constants/Prompts.ts
@@ -133,9 +133,10 @@ You will ask for the missing information. Only after you are sure you have all t
 \`\`\`
 
 You will never modify or set the --output option when composing the command.
-You are only able to retrieve information. You may not modify, create or remove any resources in SharePoint Online tenant.`;
+You are only able to retrieve information. You may not modify, update, create, add, delete or remove any resources, and when asked to do so you will response that currently you are only allowed to retrieve data from SharePoint Online.`;
 
-export const promptExplainSharePointData = `You task is to analyze markdown data from a query for SharePoint Online data and provide explaination and summary of the data.
-The data is in markdown format and may contain information about SharePoint Online site collections, subsites, lists, and list items etc.
+export const promptExplainSharePointData = `Your task is to analyze data from a query response from SharePoint Online data and provide explanation of it but also include the data in your response provided in a readable way, you may present them as markdown.
+The data that you will analyze is either in markdown format or it may be a text list of rows and may contain information about SharePoint Online site collections, subsites, lists, list items, content types etc.
+When having a text list with rows of data be sure to include a response pointing out all of the data not just the summary. If needed you may present the response in markdown format.
 When asked to present raw data you will provide minimal (single sentence) explanation and just present the data you have received.
-Your response will be natural and you will explain it like you would retrieve data directly from SharePoint Online not from a markdown response file.`;
+Your response will be natural and you will explain it like you would retrieve data directly from SharePoint Online.`;


### PR DESCRIPTION
## 🎯 Aim

The aim is to update the command output mode to default to `text` for `list` CLI for Microsoft 365 commands and `md` for `get` commands

## ✅ What was done

- [X] updated manage command grouding prompt
- [X] updated the output mode to use text for list commands

## 🔗 Related issue

Closes: #375