### PR TITLE
Adds fast serve optional step to scaffolding form. Closes #218

### DIFF
--- a/src/constants/ProjectFileContent.ts
+++ b/src/constants/ProjectFileContent.ts
@@ -5,6 +5,7 @@ export enum ProjectFileContent {
   installReusablePropertyPaneControls = 'install-spfx-property-controls',
   installReusableReactControls = 'install-spfx-controls-react',
   installPnPJs = 'install-pnpjs',
+  installSPFxFastServe = 'install-spfx-fast-serve',
   createNVMRCFile = 'create-nvmrc-file',
   createNodeVersionFile = 'create-node-version-file',
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,6 +64,10 @@ export async function activate(context: vscode.ExtensionContext) {
 					await TerminalCommandExecuter.runCommand('npm install @pnp/sp @pnp/graph --save', terminalTitle, terminalIcon);
 				}
 
+				if (fileContents.indexOf(ProjectFileContent.installSPFxFastServe) > -1) {
+					await TerminalCommandExecuter.runCommand('spfx-fast-serve --force-install', terminalTitle, terminalIcon);
+				}
+
 				// If either of the following strings are found in the project file, run the command to get the node version
 				if (fileContents.indexOf(ProjectFileContent.createNVMRCFile) > -1 || fileContents.indexOf(ProjectFileContent.createNodeVersionFile) > -1) {
 					let nodeVersionCommand = 'node --version > ';

--- a/src/models/SpfxScaffoldCommandInput.ts
+++ b/src/models/SpfxScaffoldCommandInput.ts
@@ -8,6 +8,7 @@ export interface SpfxScaffoldCommandInput extends SpfxAddComponentCommandInput {
   shouldInstallReusablePropertyPaneControls: boolean;
   shouldInstallReusableReactControls: boolean;
   shouldInstallPnPJs: boolean;
+  shouldInstallSPFxFastServe: boolean;
   shouldCreateNodeVersionFile: boolean;
   nodeVersionManagerFile: '.nvmrc' | '.node-version';
   nodeVersionManager: 'nvm' | 'nvs' | 'none';

--- a/src/services/actions/Scaffolder.ts
+++ b/src/services/actions/Scaffolder.ts
@@ -306,6 +306,10 @@ export class Scaffolder {
             content += ` ${ProjectFileContent.installPnPJs}`;
           }
 
+          if (newSolutionInput.shouldInstallSPFxFastServe) {
+            content += ` ${ProjectFileContent.installSPFxFastServe}`;
+          }
+
           if (newSolutionInput.shouldCreateNodeVersionFile) {
             switch (newSolutionInput.nodeVersionManager) {
               case 'nvm':

--- a/src/webview/view/components/forms/spfxProject/AdditionalStep.tsx
+++ b/src/webview/view/components/forms/spfxProject/AdditionalStep.tsx
@@ -14,6 +14,8 @@ interface AdditionalStepProps {
     setShouldInstallReusableReactControls: (value: boolean) => void;
     shouldInstallPnPJs: boolean;
     setShouldInstallPnPJs: (value: boolean) => void;
+    shouldInstallSPFxFastServe: boolean;
+    setShouldInstallSPFxFastServe: (value: boolean) => void;
     shouldCreateNodeVersionFile: boolean;
     setShouldCreateNodeVersionFile: (value: boolean) => void;
     nodeVersionManager: 'nvm' | 'nvs' | 'none';
@@ -30,6 +32,8 @@ export const AdditionalStep: React.FunctionComponent<AdditionalStepProps> = ({
     setShouldInstallReusableReactControls,
     shouldInstallPnPJs,
     setShouldInstallPnPJs,
+    shouldInstallSPFxFastServe,
+    setShouldInstallSPFxFastServe,
     shouldCreateNodeVersionFile,
     setShouldCreateNodeVersionFile,
     setNodeVersionManagerFile,
@@ -113,6 +117,12 @@ export const AdditionalStep: React.FunctionComponent<AdditionalStepProps> = ({
                     setValue={setShouldInstallPnPJs}
                     label='Install PnPjs (@pnp/sp, @pnp/graph)'
                     link='https://pnp.github.io/pnpjs/' />
+
+                <PackageSelector
+                    value={shouldInstallSPFxFastServe}
+                    setValue={setShouldInstallSPFxFastServe}
+                    label='Configure SPFx Fast Serve'
+                    link='https://github.com/s-KaiNet/spfx-fast-serve' />
 
                 {nodeVersionManager !== 'none' &&
                     <PackageSelector

--- a/src/webview/view/components/forms/spfxProject/ScaffoldSpfxProjectView.tsx
+++ b/src/webview/view/components/forms/spfxProject/ScaffoldSpfxProjectView.tsx
@@ -26,6 +26,7 @@ export const ScaffoldSpfxProjectView: React.FunctionComponent<IScaffoldSpfxProje
   const [shouldInstallReusablePropertyPaneControls, setShouldInstallReusablePropertyPaneControls] = useState<boolean>(false);
   const [shouldInstallReusableReactControls, setShouldInstallReusableReactControls] = useState<boolean>(false);
   const [shouldInstallPnPJs, setShouldInstallPnPJs] = useState<boolean>(false);
+  const [shouldInstallSPFxFastServe, setShouldInstallSPFxFastServe] = useState<boolean>(false);
   const [shouldCreateNodeVersionFile, setShouldCreateNodeVersionFile] = useState<boolean>(false);
   const [nodeVersionManager, setNodeVersionManager] = useState<'nvm' | 'nvs' | 'none'>('nvm');
   const [nodeVersionManagerFile, setNodeVersionManagerFile] = useState<'.nvmrc' | '.node-version'>('.nvmrc');
@@ -82,6 +83,7 @@ export const ScaffoldSpfxProjectView: React.FunctionComponent<IScaffoldSpfxProje
         shouldInstallReusablePropertyPaneControls,
         shouldInstallReusableReactControls,
         shouldInstallPnPJs,
+        shouldInstallSPFxFastServe,
         shouldCreateNodeVersionFile,
         nodeVersionManagerFile,
         nodeVersionManager
@@ -130,6 +132,8 @@ export const ScaffoldSpfxProjectView: React.FunctionComponent<IScaffoldSpfxProje
             setShouldInstallReusableReactControls={setShouldInstallReusableReactControls}
             shouldInstallPnPJs={shouldInstallPnPJs}
             setShouldInstallPnPJs={setShouldInstallPnPJs}
+            shouldInstallSPFxFastServe={shouldInstallSPFxFastServe}
+            setShouldInstallSPFxFastServe={setShouldInstallSPFxFastServe}
             shouldCreateNodeVersionFile={shouldCreateNodeVersionFile}
             setShouldCreateNodeVersionFile={setShouldCreateNodeVersionFile}
             setNodeVersionManagerFile={setNodeVersionManagerFile}


### PR DESCRIPTION
## 🎯 Aim

The aim is to add SPFx fast serve support to project scaffolding so that it may be selected in as and optional dependency to install and configure

## ✅ What was done

- [X] adds spfx-fast-serve optional step

## 🔗 Related issue

Closes: #218