### PR TITLE
🚀 Adds 'Set Form Customizer' command to the SharePoint Framework Toolkit, Closes #348

### DIFF
--- a/package.json
+++ b/package.json
@@ -469,8 +469,7 @@
 			{
 				"command": "spfx-toolkit.setFormCustomizer",
 				"title": "Set Form Customizer",
-				"category": "SharePoint Framework Toolkit",
-				"icon": "$(file-code)"
+				"category": "SharePoint Framework Toolkit"
 			},
 			{
 				"command": "spfx-toolkit.showMoreActions",

--- a/package.json
+++ b/package.json
@@ -467,6 +467,12 @@
 				"icon": "$(sync)"
 			},
 			{
+				"command": "spfx-toolkit.setFormCustomizer",
+				"title": "Set Form Customizer",
+				"category": "SharePoint Framework Toolkit",
+				"icon": "$(file-code)"
+			},
+			{
 				"command": "spfx-toolkit.showMoreActions",
 				"title": "...",
 				"category": "SharePoint Framework Toolkit",

--- a/src/constants/Commands.ts
+++ b/src/constants/Commands.ts
@@ -60,5 +60,8 @@ export const Commands = {
   enableAppCatalogApp: `${EXTENSION_NAME}.enableAppCatalogApp`,
   disableAppCatalogApp: `${EXTENSION_NAME}.disableAppCatalogApp`,
   upgradeAppCatalogApp: `${EXTENSION_NAME}.upgradeAppCatalogApp`,
-  showMoreActions: `${EXTENSION_NAME}.showMoreActions`
+  showMoreActions: `${EXTENSION_NAME}.showMoreActions`,
+
+  // Set form customizer
+  setFormCustomizer: `${EXTENSION_NAME}.setFormCustomizer`
 };

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -310,8 +310,8 @@ export class CommandPanel {
 
     actionCommands.push(new ActionTreeItem('Add new component', '', { name: 'add', custom: false }, undefined, Commands.addToProject));
     actionCommands.push(new ActionTreeItem('Scaffold CI/CD Workflow', '', { name: 'rocket', custom: false }, undefined, Commands.pipeline));
-    actionCommands.push(new ActionTreeItem('View samples', '', { name: 'library', custom: false }, undefined, Commands.samplesGallery));
     actionCommands.push(new ActionTreeItem('Set Form Customizer', '', { name: 'checklist', custom: false }, undefined, Commands.setFormCustomizer));
+    actionCommands.push(new ActionTreeItem('View samples', '', { name: 'library', custom: false }, undefined, Commands.samplesGallery));
 
     window.registerTreeDataProvider('pnp-view-actions', new ActionTreeDataProvider(actionCommands));
   }

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -311,6 +311,7 @@ export class CommandPanel {
     actionCommands.push(new ActionTreeItem('Add new component', '', { name: 'add', custom: false }, undefined, Commands.addToProject));
     actionCommands.push(new ActionTreeItem('Scaffold CI/CD Workflow', '', { name: 'rocket', custom: false }, undefined, Commands.pipeline));
     actionCommands.push(new ActionTreeItem('View samples', '', { name: 'library', custom: false }, undefined, Commands.samplesGallery));
+    actionCommands.push(new ActionTreeItem('Set Form Customizer', '', { name: 'checklist', custom: false }, undefined, Commands.setFormCustomizer));
 
     window.registerTreeDataProvider('pnp-view-actions', new ActionTreeDataProvider(actionCommands));
   }

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -69,6 +69,9 @@ export class CliActions {
     subscriptions.push(
       commands.registerCommand(Commands.upgradeAppCatalogApp, CliActions.upgradeAppCatalogApp)
     );
+    subscriptions.push(
+      commands.registerCommand(Commands.setFormCustomizer, CliActions.setFormCustomizer)
+    );
   }
 
   /**
@@ -919,5 +922,91 @@ export class CliActions {
     } else {
       Notifications.error(`${fileName}.tour file not found in path ${path.join(wsFolder.uri.fsPath, '.tours')}. Cannot start Code Tour.`);
     }
+  }
+
+  /**
+   * Sets the form customizer for a content type on a list.
+   */
+  public static async setFormCustomizer() {
+    const siteUrl = await window.showInputBox({
+      prompt: 'Enter the site URL',
+      ignoreFocusOut: true,
+      validateInput: (value) => value ? undefined : 'Site URL is required'
+    });
+
+    if (!siteUrl) {
+      return;
+    }
+
+    const listTitle = await window.showInputBox({
+      prompt: 'Enter the list title',
+      ignoreFocusOut: true,
+      validateInput: (value) => value ? undefined : 'List title is required'
+    });
+
+    if (!listTitle) {
+      return;
+    }
+
+    const contentType = await window.showInputBox({
+      prompt: 'Enter the Content Type name',
+      ignoreFocusOut: true,
+      validateInput: (value) => value ? undefined : 'Content Type name is required'
+    });
+
+    if (!contentType) {
+      return;
+    }
+
+    const editFormClientSideComponentId = await window.showInputBox({
+      prompt: 'Enter the Edit form customizer (leave empty to skip)',
+      ignoreFocusOut: true
+    });
+
+    const newFormClientSideComponentId  = await window.showInputBox({
+      prompt: 'Enter the New form customizer (leave empty to skip)',
+      ignoreFocusOut: true
+    });
+
+    const displayFormClientSideComponentId = await window.showInputBox({
+      prompt: 'Enter the View form customizer (leave empty to skip)',
+      ignoreFocusOut: true
+    });
+
+    const commandOptions: any = {
+      webUrl: siteUrl,
+      listTitle: listTitle,
+      name: contentType
+    };
+
+    if (editFormClientSideComponentId) {
+      commandOptions.EditFormClientSideComponentId = editFormClientSideComponentId;
+    }
+
+    if (newFormClientSideComponentId ) {
+      commandOptions.newFormCustomizer = newFormClientSideComponentId ;
+    }
+
+    if (displayFormClientSideComponentId) {
+      commandOptions.DisplayFormClientSideComponentId = displayFormClientSideComponentId;
+    }
+
+    await window.withProgress({
+      location: ProgressLocation.Notification,
+      title: 'Setting form customizer...',
+      cancellable: true
+    }, async (progress: Progress<{ message?: string; increment?: number }>) => {
+      try {
+        const result = await CliExecuter.execute('spo contenttype set', 'json', commandOptions);
+        if (result.stderr) {
+          Notifications.error(result.stderr);
+        } else {
+          Notifications.info('Form customizer set successfully.');
+        }
+      } catch (e: any) {
+        const message = e?.error?.message;
+        Notifications.error(message);
+      }
+    });
   }
 }

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -928,15 +928,34 @@ export class CliActions {
    * Sets the form customizer for a content type on a list.
    */
   public static async setFormCustomizer() {
-    const siteUrl = await window.showInputBox({
-      prompt: 'Enter the site URL',
+    const relativeUrl = await window.showInputBox({
+      prompt: 'Enter the relative URL of the site',
       ignoreFocusOut: true,
-      validateInput: (value) => value ? undefined : 'Site URL is required'
+      placeHolder: 'e.g., sites/sales',
+      validateInput: (input) => {
+        if (!input) {
+          return 'site URL is required';
+        }
+
+        const trimmedInput = input.trim();
+
+        if (trimmedInput.startsWith('https://')) {
+          return 'Please provide a relative URL, not an absolute URL.';
+        }
+        if (trimmedInput.startsWith('/')) {
+          return 'Please provide a relative URL without a leading slash.';
+        }
+
+        return undefined;
+      }
     });
 
-    if (!siteUrl) {
+    if (relativeUrl === undefined) {
+      Notifications.warning('No site URL provided. Setting form customizer aborted.');
       return;
     }
+
+    const siteUrl = `${EnvironmentInformation.tenantUrl}/${relativeUrl.trim()}`;
 
     const listTitle = await window.showInputBox({
       prompt: 'Enter the list title',
@@ -945,6 +964,7 @@ export class CliActions {
     });
 
     if (!listTitle) {
+      Notifications.warning('No list title provided. Setting form customizer aborted.');
       return;
     }
 
@@ -955,21 +975,22 @@ export class CliActions {
     });
 
     if (!contentType) {
+      Notifications.warning('No content type name provided. Setting form customizer aborted.');
       return;
     }
 
     const editFormClientSideComponentId = await window.showInputBox({
-      prompt: 'Enter the Edit form customizer (leave empty to skip)',
+      prompt: 'Enter the Edit form customizer ID (leave empty to skip)',
       ignoreFocusOut: true
     });
 
-    const newFormClientSideComponentId  = await window.showInputBox({
-      prompt: 'Enter the New form customizer (leave empty to skip)',
+    const newFormClientSideComponentId = await window.showInputBox({
+      prompt: 'Enter the New form customizer ID (leave empty to skip)',
       ignoreFocusOut: true
     });
 
     const displayFormClientSideComponentId = await window.showInputBox({
-      prompt: 'Enter the View form customizer (leave empty to skip)',
+      prompt: 'Enter the View form customizer ID (leave empty to skip)',
       ignoreFocusOut: true
     });
 
@@ -984,7 +1005,7 @@ export class CliActions {
     }
 
     if (newFormClientSideComponentId ) {
-      commandOptions.newFormCustomizer = newFormClientSideComponentId ;
+      commandOptions.NewFormClientSideComponentId = newFormClientSideComponentId ;
     }
 
     if (displayFormClientSideComponentId) {


### PR DESCRIPTION
## 🎯 Aim

Adds 'Set Form Customizer' command to the SharePoint Framework Toolkit, to set the view, edit or new form with a form customizer

## 📷 Result

https://github.com/user-attachments/assets/1ac118ed-ad4b-44bb-946f-94c228aa0d81

## ✅ What was done

- [X] Add action to set the view, edit & new form with a form customizer

## 🔗 Related issue

Closes #348