### PR TITLE
Adds support for MS Teams in GitHub Copilot `/manage` chat command

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
 	"name": "viva-connections-toolkit",
-	"version": "4.3.0",
+	"version": "4.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "viva-connections-toolkit",
-			"version": "4.3.0",
+			"version": "4.3.1",
 			"license": "MIT",
 			"dependencies": {
 				"@pnp/cli-microsoft365": "6.11.0",

--- a/package.json
+++ b/package.json
@@ -467,6 +467,11 @@
 				"icon": "$(sync)"
 			},
 			{
+				"command": "spfx-toolkit.setFormCustomizer",
+				"title": "Set Form Customizer",
+				"category": "SharePoint Framework Toolkit"
+			},
+			{
 				"command": "spfx-toolkit.showMoreActions",
 				"title": "...",
 				"category": "SharePoint Framework Toolkit",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "viva-connections-toolkit",
 	"displayName": "SharePoint Framework Toolkit",
 	"description": "SharePoint Framework Toolkit aims to boost your productivity in developing and managing SharePoint Framework solutions helping at every stage of your development flow, from setting up your development workspace to deploying a solution straight to your tenant without the need to leave VS Code and now even create a CI/CD pipeline to introduce automate deployment of your app. This toolkit is provided by the community.",
-	"version": "4.3.0",
+	"version": "4.3.1",
 	"publisher": "m365pnp",
 	"preview": false,
 	"homepage": "https://github.com/pnp/vscode-viva",

--- a/scripts/cli-for-microsoft365-create-grounding-data.ps1
+++ b/scripts/cli-for-microsoft365-create-grounding-data.ps1
@@ -9,8 +9,10 @@ if (-not (Test-Path -Path $cliLocalProjectPath -PathType Container)) {
 [hashtable]$commandsData = @{}
 
 $allSpoCommands = Get-ChildItem -Path "$workspacePath\cli-microsoft365\docs\docs\cmd\spo\*.mdx" -Recurse -Force -Exclude "_global*"
+$allTeamsCommands = Get-ChildItem -Path "$workspacePath\cli-microsoft365\docs\docs\cmd\teams\*.mdx" -Recurse -Force -Exclude "_global*"
+$allCommands = $allSpoCommands + $allTeamsCommands
 
-foreach ($command in $allSpoCommands) {
+foreach ($command in $allCommands) {
     $commandDocs = ConvertFrom-Markdown -Path $command
     $html = New-Object -Com 'HTMLFile'
     $html.write([ref]$commandDocs.Html)

--- a/src/chat/CliForMicrosoft365SpoCommands.ts
+++ b/src/chat/CliForMicrosoft365SpoCommands.ts
@@ -2,100 +2,672 @@
 
 export const Commands = [
   {
-    "Command": "m365 spo page template list",
-    "Description": "Lists all page templates in the given site",
+    "Command": "m365 spo file version list",
+    "Description": "Retrieves all versions of a file",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located`--fileUrl [fileUrl]`: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both`-i, --fileId [fileId]`: The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both",
+    "Examples": [
+      {
+        "Description": "m365 spo file version list --webUrl https://contoso.sharepoint.com --fileId 'b2307a39-e878-458b-bc90-03bc578531d6'",
+        "Example": "List file versions of a specific file based on the ID of the file"
+      },
+      {
+        "Description": "m365 spo file version list --webUrl https://contoso.sharepoint.com --fileUrl '/Shared Documents/Document.docx'",
+        "Example": "List file versions of a specific file based on the site-relative URL of the file"
+      },
+      {
+        "Description": "m365 spo file version list --webUrl https://contoso.sharepoint.com/sites/project-x --fileUrl '/sites/project-x/Shared Documents/Document.docx'",
+        "Example": "List file versions of a specific file based on the server-relative URL of the file"
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams guestsettings list",
+    "Description": "Lists guest settings for a Microsoft Teams team",
+    "Options": "`-i, --teamId`: The ID of the team for which to get the guest settings",
+    "Examples": [
+      {
+        "Description": "m365 teams guestsettings list --teamId 2609af39-7775-4f94-a3dc-0dd67657e900",
+        "Example": "Get guest settings for a Microsoft Teams team"
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams channel member list",
+    "Description": "Lists members of the specified Microsoft Teams team channel",
+    "Options": "`-i, --teamId [teamId]`: The Id of the Microsoft Teams team. Specify either `teamId` or `teamName` but not both`--teamName [teamName]`: The display name of the Microsoft Teams team. Specify either `teamId` or `teamName` but not both`-c, --channelId [channelId]`: The Id of the Microsoft Teams team channel. Specify either `channelId` or `channelName` but not both`--channelName [channelName]`: The display name of the Microsoft Teams team channel. Specify either `channelId` or `channelName` but not both`-r, --role [role]`: Filter the results to only users with the given role: owner, member, guest",
+    "Examples": [
+      {
+        "Description": "m365 teams channel member list --teamId 00000000-0000-0000-0000-000000000000 --channelId 19:00000000000000000000000000000000@thread.skype",
+        "Example": "List the members of a specified Microsoft Teams team with id 00000000-0000-0000-0000-000000000000 and channel id 19:00000000000000000000000000000000@thread.skype"
+      },
+      {
+        "Description": "m365 teams channel member list --teamName \"Team Name\" --channelName \"Channel Name\"",
+        "Example": "List the members of a specified Microsoft Teams team with name Team Name and channel with name Channel Name"
+      },
+      {
+        "Description": "m365 teams channel member list --teamId 00000000-0000-0000-0000-000000000000 --channelId 19:00000000000000000000000000000000@thread.skype --role owner",
+        "Example": "List all owners of the specified Microsoft Teams team with id 00000000-0000-0000-0000-000000000000 and channel id 19:00000000000000000000000000000000@thread.skype"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo web get",
+    "Description": "Retrieve information about the specified site",
+    "Options": "`-u, --url <url>`: URL of the site for which to retrieve the information`--withGroups`: Set if you want to return associated groups (associatedOwnerGroup, associatedMemberGroup and associatedVisitorGroup) along with other properties`--withPermissions`: Set if you want to return associated roles and permissions",
+    "Examples": [
+      {
+        "Description": "m365 spo web get --url https://contoso.sharepoint.com/subsite",
+        "Example": "Retrieve information about a site"
+      },
+      {
+        "Description": "m365 spo web get --url https://contoso.sharepoint.com/subsite --withGroups",
+        "Example": "Retrieve information about a site along with associated groups for the web"
+      },
+      {
+        "Description": "m365 spo web get --url https://contoso.sharepoint.com/subsite --withPermissions",
+        "Example": "Retrieve information about a site along with the RoleAssignments for the web"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo site apppermission list",
+    "Description": "Lists application permissions for a site",
+    "Options": "`-u, --siteUrl <siteUrl>`: URL of the site collection to retrieve information for`-i, --appId [appId]`: Id of the application to filter by`-n, --appDisplayName [appDisplayName]`: Display name of the application to filter by",
+    "Examples": [
+      {
+        "Description": "m365 spo site apppermission list --siteUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Return list of application permissions for the https://contoso.sharepoint.com/sites/project-x site collection."
+      },
+      {
+        "Description": "m365 spo site apppermission list --siteUrl https://contoso.sharepoint.com/sites/project-x --appDisplayName Foo",
+        "Example": "Return list of application permissions for the https://contoso.sharepoint.com/sites/project-x site collection and filter by an application called Foo"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo user get",
+    "Description": "Gets a site user within specific web",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the web to get the user within`-i, --id [id]`: ID of the user to retrieve information for. Use either `email`, `id` or `loginName`, but not all.`--email [email]`: Email of the user to retrieve information for. Use either `email`, `id` or `loginName`, but not all.`--loginName [loginName]`: Login name of the user to retrieve information for. Use either `email`, `id` or `loginName`, but not all.",
+    "Examples": [
+      {
+        "Description": "m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --email john.doe@mytenant.onmicrosoft.com",
+        "Example": "Get user by email for a web"
+      },
+      {
+        "Description": "m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --id 6",
+        "Example": "Get user by ID for a web"
+      },
+      {
+        "Description": "m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --loginName \"i:0#.f|membership|john.doe@mytenant.onmicrosoft.com\"",
+        "Example": "Get user by login name for a web"
+      },
+      {
+        "Description": "m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Get the currently logged-in user"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo list list",
+    "Description": "Gets all lists within the specified site",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the lists to retrieve are located.`-p, --properties [properties]`: Comma-separated list of properties to retrieve. Will retrieve all properties if not specified.`--filter [filter]`: OData filter to use to query the lists with.",
+    "Examples": [
+      {
+        "Description": "m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Return all lists located in in a specific site."
+      },
+      {
+        "Description": "m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x --properties \"BaseTemplate,ParentWebUrl\"",
+        "Example": "Return all lists located in in a specific site with specific properties."
+      },
+      {
+        "Description": "m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x --properties \"Id,Title,RootFolder/ServerRelativeUrl\"",
+        "Example": "Return all lists located in in a specific site with the Id, Title and ServerRelativeUrl properties."
+      },
+      {
+        "Description": "m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x --filter \"BaseTemplate eq 100\"",
+        "Example": "Return all lists located in in a specific site based on the given filter."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo propertybag list",
+    "Description": "Gets property bag values",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site from which the property bag value should be retrieved.`--folder [folder]`: Site-relative URL of the folder from which to retrieve property bag value. Case-sensitive.",
+    "Examples": [
+      {
+        "Description": "m365 spo propertybag list --webUrl https://contoso.sharepoint.com/sites/test",
+        "Example": "Return property bag values located in the given site"
+      },
+      {
+        "Description": "m365 spo propertybag list --webUrl https://contoso.sharepoint.com/sites/test --folder /",
+        "Example": "Return property bag values located in the given site root folder"
+      },
+      {
+        "Description": "m365 spo propertybag list --webUrl https://contoso.sharepoint.com/sites/test --folder '/Shared Documents'",
+        "Example": "Return property bag values located in the given site document library"
+      },
+      {
+        "Description": "m365 spo propertybag list --webUrl https://contoso.sharepoint.com/sites/test --folder '/Shared Documents/MyFolder'",
+        "Example": "Return property bag values located in folder in the given site document library"
+      },
+      {
+        "Description": "m365 spo propertybag list --webUrl https://contoso.sharepoint.com/sites/test --folder /Lists/MyList",
+        "Example": "Return property bag values located in the given site list"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo eventreceiver get",
+    "Description": "Retrieves specific event receiver for the specified web, site or list by event receiver name or id.",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the web for which to retrieve the event receivers.`--listTitle [listTitle]`: The title of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.`--listId [listId]`: The id of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.`--listUrl [listUrl]`: The url of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.`-n, --name [name]`: The name of the event receiver to retrieve. Specify either `name` or `id` but not both.`-i, --id [id]`: The id of the event receiver to retrieve. Specify either `name` or `id` but not both.`-s, --scope [scope]`: The scope of which to retrieve the event receivers. Can be either `site` or `web`. Defaults to `web`. Only applicable when not specifying any of the list properties.",
+    "Examples": [
+      {
+        "Description": "m365 spo eventreceiver list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --name 'PnP Test Receiver'",
+        "Example": "Retrieve event receivers in web https://contoso.sharepoint.com/sites/contoso-sales with name PnP Test Receiver."
+      },
+      {
+        "Description": "m365 spo eventreceiver list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --scope site --id c5a6444a-9c7f-4a0d-9e29-fc6fe30e34ec",
+        "Example": "Retrieve event receivers in site https://contoso.sharepoint.com/sites/contoso-sales with id c5a6444a-9c7f-4a0d-9e29-fc6fe30e34ec."
+      },
+      {
+        "Description": "m365 spo eventreceiver list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listTitle Events --name 'PnP Test Receiver'",
+        "Example": "Retrieve event receivers for list with title Events in web https://contoso.sharepoint.com/sites/contoso-sales with name PnP Test Receiver."
+      },
+      {
+        "Description": "m365 spo eventreceiver list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listId '202b8199-b9de-43fd-9737-7f213f51c991' --id c5a6444a-9c7f-4a0d-9e29-fc6fe30e34ec",
+        "Example": "Retrieve event receivers for list with ID 202b8199-b9de-43fd-9737-7f213f51c991 in web https://contoso.sharepoint.com/sites/contoso-sales with id c5a6444a-9c7f-4a0d-9e29-fc6fe30e34ec."
+      },
+      {
+        "Description": "m365 spo eventreceiver list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listUrl '/sites/contoso-sales/lists/Events' --name 'PnP Test Receiver'",
+        "Example": "Retrieve event receivers for list with url /sites/contoso-sales/lists/Events in web https://contoso.sharepoint.com/sites/contoso-sales with name PnP Test Receiver."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo list view list",
+    "Description": "Lists views configured on the specified list",
+    "Options": " `-u, --webUrl <webUrl>`: URL of the site where the list is located `-i, --listId [listId]`: ID of the list for which to list configured views. Specify either `listId`, `listTitle`, or `listUrl`. `-t, --listTitle [listTitle]`: Title of the list for which to list configured views. Specify either `listId`, `listTitle`, or `listUrl`. `--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listId` , `listTitle` or `listUrl`.",
+    "Examples": [
+      {
+        "Description": "m365 spo list view list --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle Documents",
+        "Example": "List all views for a list by title"
+      },
+      {
+        "Description": "m365 spo list view list --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf",
+        "Example": "List all views for a list by ID"
+      },
+      {
+        "Description": "m365 spo list view list --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl '/sites/project-x/lists/Events'",
+        "Example": "List all views for a list by URL"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo storageentity get",
+    "Description": "Get details for the specified tenant property",
+    "Options": "`-k, --key <key>`: Name of the tenant property to retrieve",
+    "Examples": [
+      {
+        "Description": "m365 spo storageentity get -k AnalyticsId",
+        "Example": "Show the value, description and comment of the AnalyticsId tenant property"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo sitescript get",
+    "Description": "Gets information about the specified site script",
+    "Options": "`-i, --id <id>`: Site script ID",
+    "Examples": [
+      {
+        "Description": "m365 spo sitescript get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a",
+        "Example": "Get information about the site script with ID 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo navigation node list",
+    "Description": "Lists nodes from the specified site navigation",
+    "Options": "`-u, --webUrl <webUrl>`: Absolute URL of the site for which to retrieve navigation`-l, --location <location>`: Navigation type to retrieve. Available options: `QuickLaunch,TopNavigationBar`",
+    "Examples": [
+      {
+        "Description": "m365 spo navigation node list --webUrl https://contoso.sharepoint.com/sites/team-a --location TopNavigationBar",
+        "Example": "Retrieve nodes from the top navigation"
+      },
+      {
+        "Description": "m365 spo navigation node list --webUrl https://contoso.sharepoint.com/sites/team-a --location QuickLaunch",
+        "Example": "Retrieve nodes from the quick launch"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo page get",
+    "Description": "Gets information about the specific modern page",
+    "Options": "`-n, --name <name>`: Name of the page to retrieve.`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.`--metadataOnly`: Specify to only retrieve the metadata without the section and control information.",
+    "Examples": [
+      {
+        "Description": "m365 spo page get --webUrl https://contoso.sharepoint.com/sites/team-a --name home.aspx",
+        "Example": "Get information about the modern page"
+      },
+      {
+        "Description": "m365 spo page get --webUrl https://contoso.sharepoint.com/sites/team-a --name home.aspx --metadataOnly",
+        "Example": "Get all the metadata from the modern page, without the section and control count information"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo hubsite list",
+    "Description": "Lists hub sites in the current tenant",
+    "Options": "`-i, --includeAssociatedSites`: Include the associated sites in the result (only in JSON output).",
+    "Examples": [
+      {
+        "Description": "m365 spo hubsite list",
+        "Example": "List hub sites in the current tenant"
+      },
+      {
+        "Description": "m365 spo hubsite list --includeAssociatedSites --output json",
+        "Example": "List hub sites, including their associated sites, in the current tenant. Associated site info is only shown in JSON output."
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams message list",
+    "Description": "Lists all messages from a channel in a Microsoft Teams team",
+    "Options": "`-i, --teamId <teamId>`: The ID of the team where the channel is located.`-c, --channelId <channelId>`: The ID of the channel for which to list messages.`-s, --since [since]`: Date (ISO standard, dash separator) to get delta of messages from (in last 8 months).",
+    "Examples": [
+      {
+        "Description": "m365 teams message list --teamId fce9e580-8bba-4638-ab5c-ab40016651e3 --channelId 19:eb30973b42a847a2a1df92d91e37c76a@thread.skype",
+        "Example": "List the messages from a channel of the Microsoft Teams team."
+      },
+      {
+        "Description": "--since",
+        "Example": "List the messages from a channel of the Microsoft Teams team that have been created or modified since the date specified by the --since parameter (WARNING: only captures the last 8 months of data)."
+      },
+      {
+        "Description": null,
+        "Example": "m365 teams message list --teamId fce9e580-8bba-4638-ab5c-ab40016651e3 --channelId 19:eb30973b42a847a2a1df92d91e37c76a@thread.skype --since 2019-12-31T14:00:00Z"
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams message reply list",
+    "Description": "Retrieves replies to a message from a channel in a Microsoft Teams team",
+    "Options": "`-i, --teamId <teamId>`: The ID of the team where the channel is located.`-c, --channelId <channelId>`: The ID of the channel that contains the message.`-m, --messageId <messageId>`: The ID of the message to retrieve replies for.",
+    "Examples": [
+      {
+        "Description": "m365 teams message reply list --teamId 5f5d7b71-1161-44d8-bcc1-3da710eb4171 --channelId 19:88f7e66a8dfe42be92db19505ae912a8@thread.skype --messageId 1540747442203",
+        "Example": "Retrieve the replies from a specified message from a channel of the Microsoft Teams team."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo contenttypehub get",
+    "Description": "Returns the URL of the SharePoint Content Type Hub of the Tenant",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo contenttypehub get [options]",
+        "Example": "Retrieve the Content Type Hub URL"
+      },
+      {
+        "Description": "import Global from '/docs/cmd/_global.mdx';",
+        "Example": "Returns the URL of the SharePoint Content Type Hub of the Tenant"
+      },
+      {
+        "Description": null,
+        "Example": "m365 spo contenttypehub get"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo page list",
+    "Description": "Lists all modern pages in the given site",
     "Options": "`-u, --webUrl <webUrl>`: URL of the site from which to retrieve available pages.",
     "Examples": [
       {
-        "Description": "m365 spo page template list --webUrl https://contoso.sharepoint.com/sites/team-a",
-        "Example": "Lists all page templates in the given site"
+        "Description": "m365 spo page list --webUrl https://contoso.sharepoint.com/sites/team-a",
+        "Example": "List all modern pages in the specific site"
       }
     ]
   },
   {
-    "Command": "m365 spo homesite get",
-    "Description": "Gets information about the Home Site",
+    "Command": "m365 spo sitedesign task get",
+    "Description": "Gets information about the specified site design scheduled for execution",
+    "Options": "`-i, --id <id>`: The ID of the site design task to get information for",
+    "Examples": [
+      {
+        "Description": "m365 spo sitedesign task get --id 6ec3ca5b-d04b-4381-b169-61378556d76e",
+        "Example": "Get information about the specified site design scheduled for execution"
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams app list",
+    "Description": "Lists apps from the Microsoft Teams app catalog",
+    "Options": "`--distributionMethod [distributionMethod]`: The distribution method. Allowed values `store`, `organization`, `sideloaded`.",
+    "Examples": [
+      {
+        "Description": "m365 teams app list",
+        "Example": "List all apps from the Microsoft Teams app catalog"
+      },
+      {
+        "Description": "m365 teams app list --distributionMethod 'store'",
+        "Example": "List all apps from the Microsoft Teams app catalog according to a given distribution method"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo term group list",
+    "Description": "Lists taxonomy term groups",
+    "Options": "`-u, --webUrl [webUrl]`: If specified, allows you to list term groups from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.",
+    "Examples": [
+      {
+        "Description": "m365 spo term group list",
+        "Example": "List taxonomy term groups."
+      },
+      {
+        "Description": "m365 spo term group list --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "List taxonomy term groups from the specified sitecollection."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo knowledgehub get",
+    "Description": "Gets the Knowledge Hub Site URL for your tenant",
     "Options": null,
     "Examples": [
       {
-        "Description": "m365 spo homesite get",
-        "Example": "Get information about the Home Site."
+        "Description": "m365 spo knowledgehub get",
+        "Example": "Gets the Knowledge Hub Site URL for your tenant."
       }
     ]
   },
   {
-    "Command": "m365 spo theme list",
-    "Description": "Retrieves the list of custom themes",
-    "Options": null,
+    "Command": "m365 teams tab list",
+    "Description": "Lists tabs in the specified Microsoft Teams channel",
+    "Options": "`-i, --teamId <teamId>`: The ID of the Microsoft Teams team where the channel is located`-c, --channelId <channelId>`: The ID of the channel for which to list tabs",
     "Examples": [
       {
-        "Description": "m365 spo theme list",
-        "Example": "List available themes"
+        "Description": "m365 teams tab list --teamId 00000000-0000-0000-0000-000000000000 --channelId 19:00000000000000000000000000000000@thread.skype",
+        "Example": "List all tabs in a Microsoft Teams channel"
+      },
+      {
+        "Description": "m365 teams tab list --teamId 00000000-0000-0000-0000-000000000000 --channelId 19:00000000000000000000000000000000@thread.skype --output json",
+        "Example": "Include all the values from the tab configuration and associated teams app"
       }
     ]
   },
   {
-    "Command": "m365 spo file sharinginfo get",
-    "Description": "Generates a sharing information report for the specified file",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located`--fileUrl [fileUrl]`: The server- or site-relative decoded URL of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both`-i, --fileId [fileId]`: The UniqueId (GUID) of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both",
+    "Command": "m365 spo user list",
+    "Description": "Lists all the users within specific web",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the web to list the users from",
     "Examples": [
       {
-        "Description": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located",
-        "Example": "Get file sharing information report for the file with server-relative url /sites/M365CLI/Shared Documents/SharedFile.docx located in site https://contoso.sharepoint.com/sites/project-x"
+        "Description": "m365 spo user list --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Get list of users in a web"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo listitem list",
+    "Description": "Gets a list of items from the specified list",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site from which the item should be retrieved.`-l, --listId [listId]`: ID of the list. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.`-t, --listTitle [listTitle]`: Title of the list. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.`-q, --camlQuery [camlQuery]`: CAML query to use to query the list of items with.`--fields [fields]`: Comma-separated list of fields to retrieve. Will retrieve all fields if not specified and json output is requested. Specify `camlQuery` or `fields` but not both.`-l, --filter [filter]`: OData filter to use to query the list of items with. Specify `camlQuery` or `filter` but not both.`-s, --pageSize [pageSize]`: Number of list items to return. Specify `camlQuery` or `pageSize` but not both. The default value is 5000.`-n, --pageNumber [pageNumber]`: Page number to return if `pageSize` is specified (first page is indexed as value of 0).",
+    "Examples": [
+      {
+        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Get all items from a list named Demo List"
       },
       {
-        "Description": ": The server- or site-relative decoded URL of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both",
-        "Example": "`--fileUrl [fileUrl]`"
+        "Description": "m365 spo listitem list --listId 935c13a0-cc53-4103-8b48-c1d0828eaa7f --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Get all items from a list with ID 935c13a0-cc53-4103-8b48-c1d0828eaa7f"
       },
       {
-        "Description": ": The UniqueId (GUID) of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both",
-        "Example": "`-i, --fileId [fileId]`"
+        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --fields \"ID,Title,Modified\"",
+        "Example": "Get all items from list named Demo List. For each item, retrieve the value of the ID, Title and Modified fields"
       },
       {
-        "Description": ": The URL of the site where the file is located",
+        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --fields \"ID,Title,Modified,Company/Title\"",
+        "Example": "Get all items from list named Demo List. For each item, retrieve the value of the ID, Title, Modified fields, and the value of lookup field Company"
+      },
+      {
+        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --filter \"Title eq 'Demo list item'\"",
+        "Example": "From a list named Demo List get all items with title Demo list item using an OData filter"
+      },
+      {
+        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --pageSize 100 --pageNumber 0",
+        "Example": "From a list named Demo List get the first 100 items"
+      },
+      {
+        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --pageSize 10 --pageNumber 1",
+        "Example": "From a list named Demo List get the second batch of 10 items"
+      },
+      {
+        "Description": "m365 spo listitem list --listUrl /sites/project-x/documents --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Get all items from a list by server-relative URL"
+      },
+      {
+        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --camlQuery \"<View><Query><Where><Eq><FieldRef Name='Title' /><Value Type='Text'>Demo list item</Value></Eq></Where></Query><RowLimit Paged='TRUE'>5000</RowLimit></View>\"",
+        "Example": "From a list named Demo List get all items with title Demo list item using a CAML query"
+      },
+      {
+        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --camlQuery \"<View Scope='RecursiveAll'><Query></Query><ViewFields><FieldRef Name='Title'/></ViewFields><RowLimit Paged='TRUE'>5000</RowLimit></View>\"",
+        "Example": "From a library named Demo Library with 5000+ files and folders, get all items recursively without running into a list view threshold exception, using a CAML query"
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams channel get",
+    "Description": "Gets information about the specific Microsoft Teams team channel",
+    "Options": "`--teamId [teamId]`: The ID of the team to which the channel belongs to. Specify either `teamId` or `teamName` but not both.`--teamName [teamName]`: The display name of the team to which the channel belongs to. Specify either `teamId` or `teamName` but not both.`-i, --id [id]`: The ID of the channel for which to retrieve more information. Specify either `id` or `name` but not both.`--name [name]`: The display name of the channel for which to retrieve more information. Specify either `id` or `name` but not both.`--primary`: Gets the default channel, General, of a team. If specified, id or name are not needed.",
+    "Examples": [
+      {
+        "Description": "m365 teams channel get --teamId 00000000-0000-0000-0000-000000000000 --id '19:493665404ebd4a18adb8a980a31b4986@thread.skype'",
+        "Example": "Get information about Microsoft Teams team channel with id 19:493665404ebd4a18adb8a980a31b4986@thread.skype"
+      },
+      {
+        "Description": "m365 teams channel get --teamName \"Team Name\" --name \"Channel Name\"",
+        "Example": "Get information about Microsoft Teams team channel with name Channel Name"
+      },
+      {
+        "Description": "m365 teams channel get --teamName \"Team Name\" --primary",
+        "Example": "Get information about Microsoft Teams team primary channel , i.e. General"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo group list",
+    "Description": "Lists all the groups within specific web",
+    "Options": "`-u, --webUrl <webUrl>`: Url of the web to list the group within`--associatedGroupsOnly`: Get only the associated visitor, member and owner groups of the site.",
+    "Examples": [
+      {
+        "Description": "`-u, --webUrl <webUrl>`: Url of the web to list the group within",
+        "Example": "Lists all the groups within a specific web"
+      },
+      {
+        "Description": ": Get only the associated visitor, member and owner groups of the site.",
+        "Example": "`--associatedGroupsOnly`"
+      },
+      {
+        "Description": ": Url of the web to list the group within",
         "Example": "`-u, --webUrl <webUrl>`"
       },
       {
-        "Description": "`--fileUrl [fileUrl]`",
+        "Description": "`--associatedGroupsOnly`",
         "Example": ""
       },
       {
-        "Description": "",
-        "Example": ": The server- or site-relative decoded URL of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both"
+        "Description": "m365 spo group list [options]",
+        "Example": ": Get only the associated visitor, member and owner groups of the site."
       },
       {
-        "Description": ": The UniqueId (GUID) of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both",
-        "Example": "`-i, --fileId [fileId]`"
+        "Description": "import Global from '/docs/cmd/_global.mdx';",
+        "Example": "Lists all the groups within specific web"
       },
       {
-        "Description": "Generates a sharing information report for the specified file",
-        "Example": "m365 spo file sharinginfo get [options]"
-      },
-      {
-        "Description": "m365 spo file sharinginfo get --webUrl https://contoso.sharepoint.com/sites/project-x --fileId \"b2307a39-e878-458b-bc90-03bc578531d6\"",
-        "Example": "import Global from '/docs/cmd/_global.mdx';"
+        "Description": null,
+        "Example": "m365 spo group list --webUrl \"https://contoso.sharepoint.com/sites/contoso\" --associatedGroupsOnly"
       }
     ]
   },
   {
-    "Command": "m365 spo get",
-    "Description": "Gets the context URL for the root SharePoint site collection and SharePoint tenant admin site",
+    "Command": "m365 spo navigation node get",
+    "Description": "Gets information about a specific navigation node.",
+    "Options": "`-u, --webUrl <webUrl>`: Absolute URL of the site.`--id <id>`: Id of the navigation node.",
+    "Examples": [
+      {
+        "Description": "m365 spo navigation node get --webUrl https://contoso.sharepoint.com/sites/team-a --id 2209",
+        "Example": "Retrieve information for a specific navigation node."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo hubsite data get",
+    "Description": "Get hub site data for the specified site",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site for which to retrieve hub site data.`--forceRefresh`: Set, to refresh the server cache with the latest updates.",
+    "Examples": [
+      {
+        "Description": "m365 spo hubsite data get --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Get information about the hub site data for a specific site with URL."
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams tab get",
+    "Description": "Gets information about the specified Microsoft Teams tab",
+    "Options": "`--teamId [teamId]`: The ID of the Microsoft Teams team where the tab is located. Specify either teamId or teamName but not both`--teamName [teamName]`: The display name of the Microsoft Teams team where the tab is located. Specify either teamId or teamName but not both`--channelId [channelId]`: The ID of the Microsoft Teams channel where the tab is located. Specify either channelId or channelName but not both`--channelName [channelName]`: The display name of the Microsoft Teams channel where the tab is located. Specify either channelId or channelName but not both`-i, --id [id]`: The ID of the Microsoft Teams tab. Specify either `id` or `name` but not both`-n, --name [name]`: The display name of the Microsoft Teams tab. Specify either `id` or `name` but not both",
+    "Examples": [
+      {
+        "Description": "m365 teams tab get --teamId 00000000-0000-0000-0000-000000000000 --channelId 19:00000000000000000000000000000000@thread.skype --id 1432c9da-8b9c-4602-9248-e0800f3e3f07",
+        "Example": "Get a Microsoft Teams Tab with ID 1432c9da-8b9c-4602-9248-e0800f3e3f07"
+      },
+      {
+        "Description": "m365 teams tab get --teamName \"Team Name\" --channelName \"Channel Name\" --name \"Tab Name\"",
+        "Example": "Get a Microsoft Teams Tab with name Tab Name"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo app list",
+    "Description": "Lists apps from the specified app catalog",
+    "Options": "`-s, --appCatalogScope [appCatalogScope]`: Target app catalog. `tenant,sitecollection`. Default `tenant``-u, --appCatalogUrl [appCatalogUrl]`: URL of the tenant or site collection app catalog. It must be specified when the scope is `sitecollection`",
+    "Examples": [
+      {
+        "Description": "m365 spo app list",
+        "Example": "Return the list of available apps from the tenant app catalog. Show the installed version in the site if applicable."
+      },
+      {
+        "Description": "m365 spo app list --appCatalogScope sitecollection --appCatalogUrl https://contoso.sharepoint.com/sites/site1",
+        "Example": "Return the list of available apps from a site collection app catalog of site https://contoso.sharepoint.com/sites/site1."
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams channel list",
+    "Description": "Lists channels in the specified Microsoft Teams team",
+    "Options": "`-i, --teamId [teamId]`: The ID of the team to list the channels of. Specify either `teamId` or `teamName` but not both`--teamName [teamName]`: The display name of the team to list the channels of. Specify either `teamId` or `teamName` but not both`--type [type]`: Filter the results to only channels of a given type: `standard`, `private`, `shared`. By default all channels are listed.",
+    "Examples": [
+      {
+        "Description": "m365 teams channel list --teamId 00000000-0000-0000-0000-000000000000",
+        "Example": "List all channels in a specified Microsoft Teams team with id 00000000-0000-0000-0000-000000000000"
+      },
+      {
+        "Description": "m365 teams channel list --teamName \"Team Name\"",
+        "Example": "List all channels in a specified Microsoft Teams team with name Team Name"
+      },
+      {
+        "Description": "m365 teams channel list --teamId 00000000-0000-0000-0000-000000000000 --type private",
+        "Example": "List private channels in a specified Microsoft Teams team with id 00000000-0000-0000-0000-000000000000"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo folder list",
+    "Description": "Returns all folders under the specified parent folder",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the folders to list are located.`-p, --parentFolderUrl <parentFolderUrl>`: The server- or site-relative decoded URL of the parent folder.`--fields [fields]`: Comma-separated list of fields to retrieve. Will retrieve all fields if not specified and json output is requested.`--filter [filter]`: OData filter to use to query the list of folders with.`-r, --recursive`: Set to retrieve nested folders.",
+    "Examples": [
+      {
+        "Description": "m365 spo folder list --webUrl https://contoso.sharepoint.com/sites/project-x --parentFolderUrl '/Shared Documents'",
+        "Example": "Gets list of folders under a parent folder with site-relative URL"
+      },
+      {
+        "Description": "m365 spo folder list --webUrl https://contoso.sharepoint.com/sites/project-x --parentFolderUrl '/sites/project-x/Shared Documents' --recursive",
+        "Example": "Gets recursive list of folders under a specific folder on a specific site"
+      },
+      {
+        "Description": "m365 spo folder list --webUrl https://contoso.sharepoint.com/sites/project-x --parentFolderUrl '/Shared Documents' --fields ListItemAllFields/Id --filter \"startswith(Name,'Folder')\"",
+        "Example": "Return a filtered list of folders and only return the list item ID"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo applicationcustomizer get",
+    "Description": "Get an application customizer that is added to a site.",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site.`-t, --title [title]`: The title of the Application Customizer. Specify either `title`, `id`, or `clientSideComponentId`.`-i, --id [id]`: The id of the Application Customizer. Specify either `title`, `id`, or `clientSideComponentId`.`-c, --clientSideComponentId  [clientSideComponentId]`: The Client Side Component Id (GUID) of the application customizer. Specify either `title`, `id`, or `clientSideComponentId`.`-s, --scope [scope]`: Scope of the application customizer. Allowed values: `Site`, `Web`, `All`. Defaults to `All`.",
+    "Examples": [
+      {
+        "Description": "m365 spo applicationcustomizer get --title \"Some customizer\" --webUrl https://contoso.sharepoint.com/sites/sales",
+        "Example": "Retrieves an application customizer by title."
+      },
+      {
+        "Description": "m365 spo applicationcustomizer get --id 14125658-a9bc-4ddf-9c75-1b5767c9a337 --webUrl https://contoso.sharepoint.com/sites/sales",
+        "Example": "Retrieves an application customizer by id."
+      },
+      {
+        "Description": "m365 spo applicationcustomizer get --clientSideComponentId 7096cded-b83d-4eab-96f0-df477ed7c0bc --webUrl https://contoso.sharepoint.com/sites/sales",
+        "Example": "Retrieves an application customizer by clientSideComponentId."
+      },
+      {
+        "Description": "m365 spo applicationcustomizer get --title \"Some customizer\" --webUrl https://contoso.sharepoint.com/sites/sales --scope site",
+        "Example": "Retrieves an application customizer by title available at the site scope."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo tenant applicationcustomizer list",
+    "Description": "Retrieves a list of application customizers that are installed tenant-wide",
     "Options": null,
     "Examples": [
       {
-        "Description": "m365 spo get --output json",
-        "Example": "Get the context URL for the root SharePoint site collection and SharePoint tenant admin site"
+        "Description": "m365 spo tenant applicationcustomizer list",
+        "Example": "Retrieves a list of application customizers."
       }
     ]
   },
   {
-    "Command": "m365 spo sitedesign run status get",
-    "Description": "Gets information about the site scripts executed for the specified site design",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site for which to get the information`-i, --runId <runId>`: ID of the site design applied to the site as retrieved using `spo sitedesign run list`",
+    "Command": "m365 teams team list",
+    "Description": "Lists Microsoft Teams teams in the current tenant",
+    "Options": "`-j, --joined`: Show only teams that the user is a direct member of. Specify either `joined` or `associated` but not both.`-a, --associated`: Show only teams that the user is associated with. This includes teams with direct membership and shared channels. Specify either `joined` or `associated` but not both.`--userId [userId]`: The ID of the user. Specify either `userId` or `userName` but not both. Specify only when using `joined` or `associated` options.`--userName [userName]`: The user principal name of the user. Specify either `userId` or `userName` but not both. Specify only when using `joined` or `associated` options.",
     "Examples": [
       {
-        "Description": "m365 spo sitedesign run status get --webUrl https://contoso.sharepoint.com/sites/team-a --runId b4411557-308b-4545-a3c4-55297d5cd8c8",
-        "Example": "List information about site scripts executed for the specified site design"
+        "Description": "m365 teams team list",
+        "Example": "List all Microsoft Teams in the tenant"
+      },
+      {
+        "Description": "m365 teams team list --joined",
+        "Example": "List all Microsoft Teams teams you are a direct member of"
+      },
+      {
+        "Description": "m365 teams team list --associated",
+        "Example": "List all Microsoft Teams teams you are a direct member of or are associated with via a shared channel"
+      },
+      {
+        "Description": "m365 teams team list --joined --userName john.doe@contoso.com",
+        "Example": "List all Microsoft Teams teams another user is member of"
+      },
+      {
+        "Description": "m365 teams team list --associated --userId e3aca2a8-625a-449b-bb86-cfa84c5d08de",
+        "Example": "List all Microsoft Teams teams where another user is a direct member of or is associated with via a shared channel"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo page section list",
+    "Description": "List sections in the specific modern page",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.`-n, --pageName <pageName>`: Name of the page to list sections of.",
+    "Examples": [
+      {
+        "Description": "m365 spo page section list --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx",
+        "Example": "List sections of a modern page"
       }
     ]
   },
@@ -123,28 +695,1150 @@ export const Commands = [
     ]
   },
   {
-    "Command": "m365 spo page control get",
-    "Description": "Gets information about the specific control on a modern page",
-    "Options": "`-i, --id <id>`: ID of the control to retrieve information for.`-n, --pageName <pageName>`: Name of the page where the control is located.`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.",
+    "Command": "m365 spo site list",
+    "Description": "Lists modern sites of the given type",
+    "Options": "`-t, --type [type]`: convenience option for type of sites to list. Allowed values are `TeamSite,CommunicationSite`.`--webTemplate [webTemplate]`: type of sites to list. To be used with values like `GROUP#0` and `SITEPAGEPUBLISHING#0`. Specify either `type` or `webTemplate`, but not both.  `--filter [filter]`: filter to apply when retrieving sites`--includeOneDriveSites`: use this switch to include OneDrive sites in the result when retrieving sites. Do not specify the `type` or `webTemplate` options when using this.",
     "Examples": [
       {
-        "Description": "m365 spo page control get --id 3ede60d3-dc2c-438b-b5bf-cc40bb2351e1 --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx",
-        "Example": "Get information about the control with ID 3ede60d3-dc2c-438b-b5bf-cc40bb2351e1 placed on a modern page with name home.aspx"
+        "Description": "m365 spo site list",
+        "Example": "List all sites in the currently connected tenant"
+      },
+      {
+        "Description": "m365 spo site list --type TeamSite",
+        "Example": "List all group connected team sites in the currently connected tenant"
+      },
+      {
+        "Description": "m365 spo site list --type CommunicationSite",
+        "Example": "List all communication sites in the currently connected tenant"
+      },
+      {
+        "Description": "m365 spo site list --type TeamSite --filter \"Url -like 'project'\"",
+        "Example": "List all group connected team sites that contain project in the URL"
+      },
+      {
+        "Description": "m365 spo site list --includeOneDriveSites",
+        "Example": "List all sites in the currently connected tenant including OneDrive sites"
       }
     ]
   },
   {
-    "Command": "m365 spo page get",
-    "Description": "Gets information about the specific modern page",
-    "Options": "`-n, --name <name>`: Name of the page to retrieve.`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.`--metadataOnly`: Specify to only retrieve the metadata without the section and control information.",
+    "Command": "m365 spo term set get",
+    "Description": "Gets information about the specified taxonomy term set",
+    "Options": "`-u, --webUrl [webUrl]`: If specified, allows you to get a term set from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.`-i, --id [id]`: ID of the term set to retrieve. Specify `name` or `id` but not both.`-n, --name [name]`: Name of the term set to retrieve. Specify `name` or `id` but not both.`--termGroupId [termGroupId]`: ID of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both.`--termGroupName [termGroupName]`: Name of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both.",
     "Examples": [
       {
-        "Description": "m365 spo page get --webUrl https://contoso.sharepoint.com/sites/team-a --name home.aspx",
-        "Example": "Get information about the modern page"
+        "Description": "m365 spo term set get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb --termGroupName PnPTermSets",
+        "Example": "Get information about a taxonomy term set using its ID."
       },
       {
-        "Description": "m365 spo page get --webUrl https://contoso.sharepoint.com/sites/team-a --name home.aspx --metadataOnly",
-        "Example": "Get all the metadata from the modern page, without the section and control count information"
+        "Description": "m365 spo term set get --name PnP-Organizations --termGroupId 0a099ee9-e231-4ae9-a5b6-d7f94a0d241d",
+        "Example": "Get information about a taxonomy term set using its name."
+      },
+      {
+        "Description": "m365 spo term set get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb --termGroupName PnPTermSets --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Get information about a taxonomy term set using its ID from the specified sitecollection."
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams meeting transcript list",
+    "Description": "Lists all transcripts for a given meeting",
+    "Options": "`-u, --userId [userId]`: The id of the user, omit to list meeting transcripts list for current signed in user. Use either `id`, `userName` or `email`, but not multiple.`-n, --userName [userName]`: The upn of the user, omit to list meeting transcripts list for current signed in user. Use either `id`, `userName` or `email`, but not multiple.`--email [email]`: The email of the user, omit to list meeting transcripts list for current signed in user. Use either `id`, `userName` or `email`, but not multiple.`-m, --meetingId <meetingId>`: The id of the meeting.",
+    "Examples": [
+      {
+        "Description": "m365 teams meeting transcript list --meetingId MSo1N2Y5ZGFjYy03MWJmLTQ3NDMtYjQxMy01M2EdFGkdRWHJlQ",
+        "Example": "Lists all transcripts made for the current signed in user and Microsoft Teams meeting with given id"
+      },
+      {
+        "Description": "m365 teams meeting transcript list --userName garthf@contoso.com --meetingId MSo1N2Y5ZGFjYy03MWJmLTQ3NDMtYjQxMy01M2EdFGkdRWHJlQ",
+        "Example": "Lists all transcripts for a meeting of a specific user"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo customaction get",
+    "Description": "Gets information about a user custom action for site or site collection",
+    "Options": "`-i, --id [id]`: ID of the user custom action to retrieve information for. Specify either `id`, `title` or `clientSideComponentId``-t, --title [title]`: Title of the user custom action to retrieve information for. Specify either `id`, `title` or `clientSideComponentId``-c, --clientSideComponentId [clientSideComponentId]`: clientSideComponentId of the user custom action to retrieve information for. Specify either `id`, `title` or `clientSideComponentId``-u, --webUrl <webUrl>`: Url of the site or site collection to retrieve the custom action from`-s, --scope [scope]`: Scope of the custom action. Allowed values `Site`, `Web`, `All`. Default `All`",
+    "Examples": [
+      {
+        "Description": "m365 spo customaction get --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --webUrl https://contoso.sharepoint.com/sites/test",
+        "Example": "Return details about the user custom action based on the id and a given url"
+      },
+      {
+        "Description": "m365 spo customaction get --title \"YourAppCustomizer\" --webUrl https://contoso.sharepoint.com/sites/test",
+        "Example": "Return details about the user custom action based on the title and a given url"
+      },
+      {
+        "Description": "m365 spo customaction get --clientSideComponentId \"34a019f9-6198-4053-a3b6-fbdea9a107fd\" --webUrl https://contoso.sharepoint.com/sites/test",
+        "Example": "Return details about the user custom action based on the clientSideComponentId and a given url"
+      },
+      {
+        "Description": "m365 spo customaction get --id \"058140e3-0e37-44fc-a1d3-79c487d371a3\" --webUrl https://contoso.sharepoint.com/sites/test --scope Site",
+        "Example": "Return details about the user custom action based on the id and a given url and the scope"
+      },
+      {
+        "Description": null,
+        "Example": "m365 spo customaction get --id \"058140e3-0e37-44fc-a1d3-79c487d371a3\" --webUrl https://contoso.sharepoint.com/sites/test --scope Web"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo site apppermission get",
+    "Description": "Get a specific application permissions for the site",
+    "Options": "`-u, --siteUrl <siteUrl>`: URL of the site collection where the permission to retrieve is located`-i, --id <id>`: ID of the permission to retrieve",
+    "Examples": [
+      {
+        "Description": "m365 spo site apppermission get --siteUrl https://contoso.sharepoint.com/sites/project-x --id aTowaS50fG1zLnNwLmV4dHw4OWVhNWM5NC03NzM2LTRlMjUtOTVhZC0zZmE5NWY2MmI2NmVAZGUzNDhiYzctMWFlYi00NDA2LThjYjMtOTdkYjAyMWNhZGI0",
+        "Example": "Return a specific application permissions for the https://contoso.sharepoint.com/sites/project-x site collection with permission id aTowaS50fG1zLnNwLmV4dHw4OWVhNWM5NC03NzM2LTRlMjUtOTVhZC0zZmE5NWY2MmI2NmVAZGUzNDhiYzctMWFlYi00NDA2LThjYjMtOTdkYjAyMWNhZGI0"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo page column get",
+    "Description": "Get information about a specific column of a modern page",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.`-n, --pageName <pageName>`: Name of the page to get column information of.`-s, --section <section>`: ID of the section where the column is located.`-c, --column <column>`: ID of the column for which to retrieve more information.",
+    "Examples": [
+      {
+        "Description": "m365 spo page column get --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx --section 1 --column 1",
+        "Example": "Get information about the first column in the first section of a modern page"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo get",
+    "Description": "Gets the context URL for the root SharePoint site collection and SharePoint tenant admin site",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo get --output json",
+        "Example": "Get the context URL for the root SharePoint site collection and SharePoint tenant admin site"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo sitedesign task list",
+    "Description": "Lists site designs scheduled for execution on the specified site",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site for which to list site designs scheduled for execution",
+    "Examples": [
+      {
+        "Description": "m365 spo sitedesign task list --webUrl https://contoso.sharepoint.com/sites/team-a",
+        "Example": "List site designs scheduled for execution on the specified site"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo listitem attachment get",
+    "Description": "Gets an attachment from a list item",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list item is located.`--listId [listId]`: ID of the list. Specify either `listTitle`, `listId` or `listUrl`.`--listTitle [listTitle]`: Title of the list. Specify either `listTitle`, `listId` or `listUrl`.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`.`--listItemId <listItemId>`: The ID of the list item.`-n, --fileName <fileName>`: Name of the file to get.",
+    "Examples": [
+      {
+        "Description": "m365 spo listitem attachment get --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle \"Demo List\" --listItemId 147 --fileName \"File1.jpg\"",
+        "Example": "Get an attachment from a list item by using list title."
+      },
+      {
+        "Description": "m365 spo listitem attachment get --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl \"/sites/project-x/Lists/DemoList\" --listItemId 147 --fileName \"File1.jpg\"",
+        "Example": "Get an attachment from a list item by using list URL."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo userprofile get",
+    "Description": "Get SharePoint user profile properties for the specified user",
+    "Options": "`-u, --userName <userName>`: Account name of the user",
+    "Examples": [
+      {
+        "Description": "m365 spo userprofile get --userName 'john.doe@mytenant.onmicrosoft.com'",
+        "Example": "Get SharePoint user profile for the specified user"
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams chat get",
+    "Description": "Get a Microsoft Teams chat conversation by id, participants or chat name.",
+    "Options": "`-i, --id [id]`: The ID of the chat conversation. Specify either `id`, `name` or `participants`, but not multiple.`-n, --name [name]`: The display name of the chat conversation. Specify either `id`, `name` or `participants`, but not multiple.`-p, --participants [participants]`: A comma-separated list of one or more e-mail addresses. Specify either `id`, `name` or `participants`, but not multiple.",
+    "Examples": [
+      {
+        "Description": "m365 teams chat get --id 19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+        "Example": "Get a Microsoft Teams chat conversation by id"
+      },
+      {
+        "Description": "m365 teams chat get --participants alexw@contoso.com",
+        "Example": "Get a Microsoft Teams one on one chat conversation, finding it by participant."
+      },
+      {
+        "Description": "m365 teams chat get --participants alexw@contoso.com,meganb@contoso.com",
+        "Example": "Get a Microsoft Teams group chat conversation, finding it by participants."
+      },
+      {
+        "Description": "m365 teams chat get --name \"Just a conversation\"",
+        "Example": "Get a Microsoft Teams chat conversation, finding it by display name"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo site recyclebinitem list",
+    "Description": "Lists items from recycle bin",
+    "Options": "`-u, --siteUrl <siteUrl>`: URL of the site for which to retrieve the recycle bin items`--type [type]`: Type of items which should be retrieved (listItems, folders, files)`--secondary`: Use this switch to retrieve items from secondary recycle bin",
+    "Examples": [
+      {
+        "Description": "m365 spo site recyclebinitem list --siteUrl https://contoso.sharepoint.com/site",
+        "Example": "Lists all files, items and folders from recycle bin for site https://contoso.sharepoint.com/site"
+      },
+      {
+        "Description": "m365 spo site recyclebinitem list --siteUrl https://contoso.sharepoint.com/site --type files",
+        "Example": "Lists only files from recycle bin for site https://contoso.sharepoint.com/site"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo app get",
+    "Description": "Gets information about the specific app from the specified app catalog",
+    "Options": "`-i, --id [id]`: ID of the app to retrieve information for. Specify the `id` or the `name` but not both`-n, --name [name]`: Name of the app to retrieve information for. Specify the `id` or the `name` but not both`-u, --appCatalogUrl [appCatalogUrl]`: URL of the tenant or site collection app catalog. It must be specified when the scope is `sitecollection``-s, --appCatalogScope [appCatalogScope]`: Scope of the app catalog: `tenant,sitecollection`. Default `tenant`",
+    "Examples": [
+      {
+        "Description": "m365 spo app get --id b2307a39-e878-458b-bc90-03bc578531d6",
+        "Example": "Return details about the app with ID b2307a39-e878-458b-bc90-03bc578531d6 available in the tenant app catalog."
+      },
+      {
+        "Description": "m365 spo app get --name solution.sppkg",
+        "Example": "Return details about the app with name solution.sppkg available in the tenant app catalog. Will try to detect the app catalog URL"
+      },
+      {
+        "Description": "m365 spo app get --name solution.sppkg --appCatalogUrl https://contoso.sharepoint.com/sites/apps",
+        "Example": "Return details about the app with name solution.sppkg available in the tenant app catalog using the specified app catalog URL"
+      },
+      {
+        "Description": "m365 spo app get --id b2307a39-e878-458b-bc90-03bc578531d6 --appCatalogScope sitecollection --appCatalogUrl https://contoso.sharepoint.com/sites/site1",
+        "Example": "Return details about the app with ID b2307a39-e878-458b-bc90-03bc578531d6 available in the site collection app catalog of site https://contoso.sharepoint.com/sites/site1."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo propertybag get",
+    "Description": "Gets the value of the specified property from the property bag",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site from which the property bag value should be retrieved.`-k, --key <key>`: Key of the property for which the value should be retrieved. Case-sensitive.`--folder [folder]`: Site-relative URL of the folder from which to retrieve property bag value. Case-sensitive.",
+    "Examples": [
+      {
+        "Description": "m365 spo propertybag get --webUrl https://contoso.sharepoint.com/sites/test --key key1",
+        "Example": "Returns the value of the property from the property bag located in the given site"
+      },
+      {
+        "Description": "m365 spo propertybag get --webUrl https://contoso.sharepoint.com/sites/test --key key1 --folder /",
+        "Example": "Returns the value of the property from the property bag located in root folder of the given site"
+      },
+      {
+        "Description": "m365 spo propertybag get --webUrl https://contoso.sharepoint.com/sites/test --key key1 --folder '/Shared Documents'",
+        "Example": "Returns the value of the property from the property bag located in document library of the given site"
+      },
+      {
+        "Description": "m365 spo propertybag get --webUrl https://contoso.sharepoint.com/sites/test --key key1 --folder '/Shared Documents/MyFolder'",
+        "Example": "Returns the value of the property from the property bag located in folder in a document library located in the given site"
+      },
+      {
+        "Description": "m365 spo propertybag get --webUrl https://contoso.sharepoint.com/sites/test --key key1 --folder /Lists/MyList",
+        "Example": "Returns the value of the property from the property bag located in a list in the given site"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo field list",
+    "Description": "Retrieves columns for the specified list or site",
+    "Options": "`-u, --webUrl <webUrl>`: Absolute URL of the site where fields are located`-t, --listTitle [listTitle]`: Title of the list where fields are located. Specify `listTitle`, `listId` or `listUrl``-i --listId [listId]`: ID of the list where fields are located. Specify `listTitle`, `listId` or `listUrl``--listUrl [listUrl]`: Server- or web-relative URL of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`",
+    "Examples": [
+      {
+        "Description": "`-u, --webUrl <webUrl>`: Absolute URL of the site where fields are located",
+        "Example": "Retrieves site columns for site https://contoso.sharepoint.com/sites/contoso-sales."
+      },
+      {
+        "Description": ": Title of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`",
+        "Example": "`-t, --listTitle [listTitle]`"
+      },
+      {
+        "Description": ": ID of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`",
+        "Example": "`-i --listId [listId]`"
+      },
+      {
+        "Description": ": Server- or web-relative URL of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`",
+        "Example": "`--listUrl [listUrl]`"
+      },
+      {
+        "Description": ": Absolute URL of the site where fields are located",
+        "Example": "`-u, --webUrl <webUrl>`"
+      },
+      {
+        "Description": "`-t, --listTitle [listTitle]`",
+        "Example": ""
+      },
+      {
+        "Description": "",
+        "Example": ": Title of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`"
+      },
+      {
+        "Description": ": ID of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`",
+        "Example": "`-i --listId [listId]`"
+      },
+      {
+        "Description": "`--listUrl [listUrl]`",
+        "Example": ""
+      },
+      {
+        "Description": "m365 spo field list [options]",
+        "Example": ": Server- or web-relative URL of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`"
+      },
+      {
+        "Description": "import Global from '/docs/cmd/_global.mdx';",
+        "Example": "Retrieves columns for the specified list or site"
+      },
+      {
+        "Description": null,
+        "Example": "m365 spo field list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listUrl '/sites/contoso-sales/lists/Events'"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo term get",
+    "Description": "Gets information about the specified taxonomy term",
+    "Options": "`-u, --webUrl [webUrl]`: If specified, allows you to get a term from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.`-i, --id [id]`: ID of the term to retrieve. Specify `name` or `id` but not both.`-n, --name [name]`: Name of the term to retrieve. Specify `name` or `id` but not both.`--termGroupId [termGroupId]`: ID of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both.`--termGroupName [termGroupName]`: Name of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both.`--termSetId [termSetId]`: ID of the term set to which the term belongs. Specify `termSetId` or `termSetName` but not both.`--termSetName [termSetName]`: Name of the term set to which the term belongs. Specify `termSetId` or `termSetName` but not both.",
+    "Examples": [
+      {
+        "Description": "m365 spo term get --webUrl https://contoso.sharepoint.com/sites/project-x --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb",
+        "Example": "Get information about a taxonomy term using its ID from the specified sitecollection."
+      },
+      {
+        "Description": "m365 spo term get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb",
+        "Example": "Get information about a taxonomy term using its ID."
+      },
+      {
+        "Description": "m365 spo term get --name IT --termGroupName People --termSetName Department",
+        "Example": "Get information about a taxonomy term using its name, retrieving the parent term group and term set using their names."
+      },
+      {
+        "Description": "m365 spo term get --name IT --termGroupId 5c928151-c140-4d48-aab9-54da901c7fef --termSetId 8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f",
+        "Example": "Get information about a taxonomy term using its name, retrieving the parent term group and term set using their IDs."
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams team get",
+    "Description": "Gets information about the specified Microsoft Teams team",
+    "Options": "`-i, --id [id]`: The ID of the Microsoft Teams team to retrieve information for. Specify either `id` or `name` but not both.`-n, --name [name]`: The display name of the Microsoft Teams team to retrieve information for. Specify either `id` or `name` but not both.",
+    "Examples": [
+      {
+        "Description": "m365 teams team get --id 2eaf7dcd-7e83-4c3a-94f7-932a1299c844",
+        "Example": "Get information about the Microsoft Teams team by id."
+      },
+      {
+        "Description": "m365 teams team get --name \"Team Name\"",
+        "Example": "Get information about Microsoft Teams team by name."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo folder get",
+    "Description": "Gets information about the specified folder",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the folder is located.`--url [url]`: The server- or site-relative decoded URL of the folder to retrieve. Specify either `folderUrl` or `id` but not both.`-i, --id [id]`: The UniqueId (GUID) of the folder to retrieve. Specify either `url` or `id` but not both.`--withPermissions`: Set if you want to return associated roles and permissions of the folder. ",
+    "Examples": [
+      {
+        "Description": "Please ensure the specified folder URL or folder Id does not refer to a root folder. Use \\'spo list get\\' with withPermissions instead' error.",
+        "Example": "Get folder properties for a folder with a specific site-relative URL"
+      },
+      {
+        "Description": "Please check the folder URL. Folder might not exist on the specified URL",
+        "Example": "If root level folder is passed, you will get a Please ensure the specified folder URL or folder Id does not refer to a root folder. Use \\'spo list get\\' with withPermissions instead' error. Please use the command 'spo list get'."
+      },
+      {
+        "Description": "`-u, --webUrl <webUrl>`: The URL of the site where the folder is located.",
+        "Example": "If no folder exists at the specified URL, you will get a Please check the folder URL. Folder might not exist on the specified URL error."
+      },
+      {
+        "Description": ": The server- or site-relative decoded URL of the folder to retrieve. Specify either `folderUrl` or `id` but not both.",
+        "Example": "`--url [url]`"
+      },
+      {
+        "Description": ": The UniqueId (GUID) of the folder to retrieve. Specify either `url` or `id` but not both.",
+        "Example": "`-i, --id [id]`"
+      },
+      {
+        "Description": ": Set if you want to return associated roles and permissions of the folder. ",
+        "Example": "`--withPermissions`"
+      },
+      {
+        "Description": ": The URL of the site where the folder is located.",
+        "Example": "`-u, --webUrl <webUrl>`"
+      },
+      {
+        "Description": "`--url [url]`",
+        "Example": ""
+      },
+      {
+        "Description": "",
+        "Example": ": The server- or site-relative decoded URL of the folder to retrieve. Specify either `folderUrl` or `id` but not both."
+      },
+      {
+        "Description": ": The UniqueId (GUID) of the folder to retrieve. Specify either `url` or `id` but not both.",
+        "Example": "`-i, --id [id]`"
+      },
+      {
+        "Description": "`--withPermissions`",
+        "Example": ""
+      },
+      {
+        "Description": "m365 spo folder get [options]",
+        "Example": ": Set if you want to return associated roles and permissions of the folder. "
+      },
+      {
+        "Description": "import Global from '/docs/cmd/_global.mdx';",
+        "Example": "Gets information about the specified folder"
+      },
+      {
+        "Description": null,
+        "Example": "m365 spo folder get --webUrl https://contoso.sharepoint.com/sites/test --url \"/sites/test/Shared Documents/Test1\" --withPermissions"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo listitem attachment list",
+    "Description": "Gets the attachments associated to a list item",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site from which the item should be retrieved`--listId [listId]`: ID of the list where the item should be retrieved. Specify either `listTitle`, `listId` or `listUrl``--listTitle [listTitle]`: Title of the list where the item should be retrieved. Specify either `listTitle`, `listId` or `listUrl``--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl``--listItemId <listItemId>`: ID of the list item",
+    "Examples": [
+      {
+        "Description": "m365 spo listitem attachment list --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle \"Demo List\" --listItemId 147",
+        "Example": "Gets the attachments from list item with listItemId 147 in list with title Demo List in site https://contoso.sharepoint.com/sites/project-x"
+      },
+      {
+        "Description": "m365 spo listitem attachment list --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf --listItemId 147",
+        "Example": "Gets the attachments from list item with listItemId 147 in list with id 0cd891ef-afce-4e55-b836-fce03286cccf in site https://contoso.sharepoint.com/sites/project-x"
+      },
+      {
+        "Description": "m365 spo listitem attachment list --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl /sites/project-x/Documents --listItemId 147",
+        "Example": "Gets the attachments from a specific list item in a specific list obtained by server-relative URL in a specific site"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo page control list",
+    "Description": "Lists controls on the specific modern page",
+    "Options": "`-n, --pageName <pageName>`: Name of the page to list controls of.`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.",
+    "Examples": [
+      {
+        "Description": "m365 spo page control list --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx",
+        "Example": "List controls on the modern page"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo orgnewssite list",
+    "Description": "Lists all organizational news sites",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo orgnewssite list",
+        "Example": "List all organizational news sites"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo orgassetslibrary list",
+    "Description": "List all libraries that are assigned as asset library",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo orgassetslibrary list",
+        "Example": "List all libraries that are assigned as asset library"
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams team app list",
+    "Description": "List apps installed in the specified team",
+    "Options": "`-i, --teamId [teamId]`: The id of the Microsoft Teams team. Specify either `teamId` or `teamName` but not both.`-n, --teamName [teamName]`: The name of the Microsoft Teams team. Specify either `teamId` or `teamName` but not both.",
+    "Examples": [
+      {
+        "Description": "m365 teams team app list --teamId 2eaf7dcd-7e83-4c3a-94f7-932a1299c844",
+        "Example": "List applications installed in the specified Microsoft Teams team by id."
+      },
+      {
+        "Description": "m365 teams team app list --teamName \"Team Name\"",
+        "Example": "List applications installed in the specified Microsoft Teams team by name."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo hubsite get",
+    "Description": "Gets information about the specified hub site",
+    "Options": "`-i, --id [id]`: ID of the hub site. Specify either `id`, `title`, or `url` but not multiple.`-t, --title [title]`: Title of the hub site. Specify either `id`, `title`, or `url` but not multiple.`-u, --url [url]`: URL of the hub site. Specify either `id`, `title`, or `url` but not multiple.`--includeAssociatedSites`: Include the associated sites in the result (only in JSON output)",
+    "Examples": [
+      {
+        "Description": "m365 spo hubsite get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a",
+        "Example": "Get information about the hub site with specific ID."
+      },
+      {
+        "Description": "m365 spo hubsite get --title 'My Hub Site'",
+        "Example": "Get information about the hub site with specific title."
+      },
+      {
+        "Description": "m365 spo hubsite get --url 'https://contoso.sharepoint.com/sites/HubSite'",
+        "Example": "Get information about the hub site with specific URL."
+      },
+      {
+        "Description": "m365 spo hubsite get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a --includeAssociatedSites --output json",
+        "Example": "Get information about the hub site with specific ID, including its associated sites. Associated site info is only shown in JSON output."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo list sitescript get",
+    "Description": "Extracts a site script from a SharePoint list",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list to extract the site script from is located.`-l, --listId [listId]`: ID of the list to extract the site script from. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.`-t, --listTitle [listTitle]`: Title of the list to extract the site script from. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.",
+    "Examples": [
+      {
+        "Description": "m365 spo list sitescript get --listTitle ContosoList --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Extract a site script from an existing SharePoint list with specified title located in the specified site."
+      },
+      {
+        "Description": "m365 spo list sitescript get --listId cc27a922-8224-4296-90a5-ebbc54da2e85 --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Extract a site script from an existing SharePoint list with specified id located in the specified site."
+      },
+      {
+        "Description": "m365 spo list sitescript get --listUrl 'sites/project-x/Documents' --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Extract a site script from an existing SharePoint list with specified server relative url located in the specified site."
+      },
+      {
+        "Description": "m365 spo list sitescript get --listUrl 'Shared Documents' --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Extract a site script from an existing SharePoint list with specified site-relative URL located in the specified site."
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams chat member list",
+    "Description": "Lists all members from a Microsoft Teams chat conversation.",
+    "Options": "`-i, --chatId <chatId>`: The ID of the chat conversation",
+    "Examples": [
+      {
+        "Description": "m365 teams chat member list --chatId 19:8b081ef6-4792-4def-b2c9-c363a1bf41d5_5031bb31-22c0-4f6f-9f73-91d34ab2b32d@unq.gbl.spaces",
+        "Example": "List the members from a Microsoft Teams chat conversation"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo eventreceiver list",
+    "Description": "Retrieves event receivers for the specified web, site or list.",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the web for which to retrieve the event receivers.`--listTitle [listTitle]`: The title of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.`--listId [listId]`: The id of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.`--listUrl [listUrl]`: The url of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.`-s, --scope [scope]`: The scope of which to retrieve the Event Receivers. Can be either \"site\" or \"web\". Defaults to \"web\". Only applicable when not specifying any of the list properties.",
+    "Examples": [
+      {
+        "Description": "`-u, --webUrl <webUrl>`",
+        "Example": "Retrieves event receivers in web https://contoso.sharepoint.com/sites/contoso-sales."
+      },
+      {
+        "Description": "`--listTitle [listTitle]`",
+        "Example": ": The URL of the web for which to retrieve the event receivers."
+      },
+      {
+        "Description": "`--listId [listId]`",
+        "Example": ": The title of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`."
+      },
+      {
+        "Description": "`--listUrl [listUrl]`",
+        "Example": ": The id of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`."
+      },
+      {
+        "Description": "`-s, --scope [scope]`",
+        "Example": ": The url of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`."
+      },
+      {
+        "Description": "`-u, --webUrl <webUrl>`",
+        "Example": ": The scope of which to retrieve the Event Receivers. Can be either \"site\" or \"web\". Defaults to \"web\". Only applicable when not specifying any of the list properties."
+      },
+      {
+        "Description": "",
+        "Example": ": The URL of the web for which to retrieve the event receivers."
+      },
+      {
+        "Description": ": The title of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.",
+        "Example": "`--listTitle [listTitle]`"
+      },
+      {
+        "Description": "`--listId [listId]`",
+        "Example": ""
+      },
+      {
+        "Description": "",
+        "Example": ": The id of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`."
+      },
+      {
+        "Description": ": The url of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.",
+        "Example": "`--listUrl [listUrl]`"
+      },
+      {
+        "Description": "`-s, --scope [scope]`",
+        "Example": ""
+      },
+      {
+        "Description": "m365 spo eventreceiver list [options]",
+        "Example": ": The scope of which to retrieve the Event Receivers. Can be either \"site\" or \"web\". Defaults to \"web\". Only applicable when not specifying any of the list properties."
+      },
+      {
+        "Description": "import Global from '/docs/cmd/_global.mdx';",
+        "Example": "Retrieves event receivers for the specified web, site or list."
+      },
+      {
+        "Description": null,
+        "Example": "m365 spo eventreceiver list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listUrl '/sites/contoso-sales/lists/Events'"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo group member list",
+    "Description": "List the members of a SharePoint Group",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the SharePoint site`--groupId [groupId]`: Id of the SharePoint group. Use either `groupName` or `groupId`, but not both`--groupName [groupName]`: Name of the SharePoint group. Use either `groupName` or `groupId`, but not both",
+    "Examples": [
+      {
+        "Description": "`-u, --webUrl <webUrl>`: URL of the SharePoint site`--groupId [groupId]`",
+        "Example": "List the members of the group with ID 5 for web https://contoso.sharepoint.com/sites/SiteA"
+      },
+      {
+        "Description": "`--groupName [groupName]`",
+        "Example": ": Id of the SharePoint group. Use either `groupName` or `groupId`, but not both"
+      },
+      {
+        "Description": "`-u, --webUrl <webUrl>`",
+        "Example": ": Name of the SharePoint group. Use either `groupName` or `groupId`, but not both"
+      },
+      {
+        "Description": "",
+        "Example": ": URL of the SharePoint site"
+      },
+      {
+        "Description": ": Id of the SharePoint group. Use either `groupName` or `groupId`, but not both",
+        "Example": "`--groupId [groupId]`"
+      },
+      {
+        "Description": "`--groupName [groupName]`",
+        "Example": ""
+      },
+      {
+        "Description": "m365 spo group member list [options]",
+        "Example": ": Name of the SharePoint group. Use either `groupName` or `groupId`, but not both"
+      },
+      {
+        "Description": "import Global from '/docs/cmd/_global.mdx';",
+        "Example": "List the members of a SharePoint Group"
+      },
+      {
+        "Description": null,
+        "Example": "m365 spo group member list --webUrl https://contoso.sharepoint.com/sites/SiteA --groupName \"Contoso Site Members\""
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo file sharinglink list",
+    "Description": "Lists all the sharing links of a specific file",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located.`--fileUrl [fileUrl]`: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both.`--fileId [fileId]`: The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.`-s, --scope [scope]`: Filter the results to only sharing links of a given scope: `anonymous`, `users` or `organization`. By default all sharing links are listed.",
+    "Examples": [
+      {
+        "Description": "m365 spo file sharinglink list --webUrl https://contoso.sharepoint.com/sites/demo --fileId daebb04b-a773-4baa-b1d1-3625418e3234",
+        "Example": "List sharing links of a file by id"
+      },
+      {
+        "Description": "m365 spo file sharinglink list --webUrl https://contoso.sharepoint.com/sites/demo --fileUrl \"/sites/demo/shared documents/document.docx\"",
+        "Example": "List sharing links of a file by url"
+      },
+      {
+        "Description": "m365 spo file sharinglink list --webUrl https://contoso.sharepoint.com/sites/demo --fileUrl \"/sites/demo/shared documents/document.docx\" --scope anonymous",
+        "Example": "List anonymous sharing links of a file by url"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo roledefinition list",
+    "Description": "Gets list of role definitions for the specified site",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site for which to retrieve role definitions.",
+    "Examples": [
+      {
+        "Description": "m365 spo roledefinition list --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Return list of role definitions for the given site"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo file sharinglink get",
+    "Description": "Gets details about a specific sharing link of a file",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located.`--fileUrl [fileUrl]`: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both.`--fileId [fileId]`: The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.`-i, --id <id>`: The ID of the sharing link.",
+    "Examples": [
+      {
+        "Description": "m365 spo file sharinglink get --webUrl 'https://contoso.sharepoint.com/sites/demo' --fileId daebb04b-a773-4baa-b1d1-3625418e3234 --id 1ba739c5-e693-4c16-9dfa-042e4ec62972",
+        "Example": "Gets a specific sharing link of a file by id."
+      },
+      {
+        "Description": "m365 spo file sharinglink get --webUrl 'https://contoso.sharepoint.com/sites/demo' --fileUrl 'Shared Documents/document.docx' --id 1ba739c5-e693-4c16-9dfa-042e4ec62972",
+        "Example": "Gets a specific sharing link of a file by a specified site-relative URL."
+      },
+      {
+        "Description": "m365 spo file sharinglink get --webUrl 'https://contoso.sharepoint.com/sites/demo' --fileUrl '/sites/demo/Shared Documents/document.docx' --id 1ba739c5-e693-4c16-9dfa-042e4ec62972",
+        "Example": "Gets a specific sharing link of a file by a specified server-relative URL."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo externaluser list",
+    "Description": "Lists external users in the tenant",
+    "Options": "`--filter [filter]`: Limits the results to only those users whose first name, last name or email address begins with the text in the string, using a case-insensitive comparison`-p, --pageSize [pageSize]`: Specifies the maximum number of users to be returned in the collection. The value must be less than or equal to `50``-i, --position [position]`: Use to specify the zero-based index of the position in the sorted collection of the first result to be returned`-s, --sortOrder [sortOrder]`: Specifies the sort results in Ascending or Descending order on the `SPOUser.Email` property should occur. Allowed values `asc|desc`. Default `asc``-u, --siteUrl [siteUrl]`: Specifies the site to retrieve external users for. If no site is specified, the external users for all sites are returned",
+    "Examples": [
+      {
+        "Description": "To use this command you have to have permissions to access the tenant admin site.",
+        "Example": "List all external users from the current tenant. Show the first batch of 50 users."
+      },
+      {
+        "Description": ": Limits the results to only those users whose first name, last name or email address begins with the text in the string, using a case-insensitive comparison",
+        "Example": "`--filter [filter]`"
+      },
+      {
+        "Description": ": Specifies the maximum number of users to be returned in the collection. The value must be less than or equal to `50`",
+        "Example": "`-p, --pageSize [pageSize]`"
+      },
+      {
+        "Description": ": Use to specify the zero-based index of the position in the sorted collection of the first result to be returned",
+        "Example": "`-i, --position [position]`"
+      },
+      {
+        "Description": ": Specifies the sort results in Ascending or Descending order on the `SPOUser.Email` property should occur. Allowed values `asc|desc`. Default `asc`",
+        "Example": "`-s, --sortOrder [sortOrder]`"
+      },
+      {
+        "Description": ": Specifies the site to retrieve external users for. If no site is specified, the external users for all sites are returned",
+        "Example": "`-u, --siteUrl [siteUrl]`"
+      },
+      {
+        "Description": ": Limits the results to only those users whose first name, last name or email address begins with the text in the string, using a case-insensitive comparison",
+        "Example": "`--filter [filter]`"
+      },
+      {
+        "Description": "`-p, --pageSize [pageSize]`",
+        "Example": ""
+      },
+      {
+        "Description": "",
+        "Example": ": Specifies the maximum number of users to be returned in the collection. The value must be less than or equal to `50`"
+      },
+      {
+        "Description": ": Use to specify the zero-based index of the position in the sorted collection of the first result to be returned",
+        "Example": "`-i, --position [position]`"
+      },
+      {
+        "Description": "`-s, --sortOrder [sortOrder]`",
+        "Example": ""
+      },
+      {
+        "Description": "",
+        "Example": ": Specifies the sort results in Ascending or Descending order on the `SPOUser.Email` property should occur. Allowed values `asc|desc`. Default `asc`"
+      },
+      {
+        "Description": ": Specifies the site to retrieve external users for. If no site is specified, the external users for all sites are returned",
+        "Example": "`-u, --siteUrl [siteUrl]`"
+      },
+      {
+        "Description": "Lists external users in the tenant",
+        "Example": "m365 spo externaluser list [options]"
+      },
+      {
+        "Description": "m365 spo externaluser list --pageSize 50 --position 0 --sortOrder desc",
+        "Example": "import Global from '/docs/cmd/_global.mdx';"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo homesite get",
+    "Description": "Gets information about the Home Site",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo homesite get",
+        "Example": "Get information about the Home Site."
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams chat list",
+    "Description": "Lists all Microsoft Teams chat conversations for the current or a specific user.",
+    "Options": "`-t, --type [type]`: The chat type to optionally filter chat conversations by type. The value can be `oneOnOne`, `group` or `meeting`.`--userId [userId]`: ID of the user. Has to be specified when using application permissions. Specify either `userId` or `userName`, but not both.`--userName [userName]`: UPN of the user. Has to be specified when using application permissions. Specify either `userId` or `userName`, but not both.",
+    "Examples": [
+      {
+        "Description": "m365 teams chat list",
+        "Example": "List all the Microsoft Teams chat conversations of the current user."
+      },
+      {
+        "Description": "m365 teams chat list --userId e6296ed0-4b7d-4ace-aed4-f6b7371ce060 --type oneOnOne",
+        "Example": "List only the one on one Microsoft Teams chat conversations of a specific user retrieved by id."
+      },
+      {
+        "Description": "m365 teams chat list --userName 'john@contoso.com' --type group ",
+        "Example": "List only the group Microsoft Teams chat conversations of a specific user retrieved by mail"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo tenant settings list",
+    "Description": "Lists the global tenant settings",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo tenant settings list",
+        "Example": "Lists the settings of the tenant"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo cdn policy list",
+    "Description": "Lists CDN policies settings for the current SharePoint Online tenant",
+    "Options": "`-t, --cdnType [cdnType]`: Type of CDN to manage. `Public,Private`. Default `Public`",
+    "Examples": [
+      {
+        "Description": "m365 spo cdn policy list",
+        "Example": "Show the list of policies configured for the Public CDN"
+      },
+      {
+        "Description": "m365 spo cdn policy list --cdnType Private",
+        "Example": "Show the list of policies configured for the Private CDN"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo serviceprincipal permissionrequest list",
+    "Description": "Lists pending permission requests",
+    "Options": "m365 spo sp permissionrequest list",
+    "Examples": [
+      {
+        "Description": null,
+        "Example": "The admin role that's required to list permissions depends on the API. To approve permissions to any of the third-party APIs registered in the tenant, the application administrator role is sufficient. To approve permissions for Microsoft Graph or any other Microsoft API, the Global Administrator role is required."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo theme list",
+    "Description": "Retrieves the list of custom themes",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo theme list",
+        "Example": "List available themes"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo cdn origin list",
+    "Description": "List CDN origins settings for the current SharePoint Online tenant",
+    "Options": "`-t, --type [type]`: Type of CDN to manage. `Public,Private`. Default `Public`",
+    "Examples": [
+      {
+        "Description": "m365 spo cdn origin list",
+        "Example": "Show the list of origins configured for the Public CDN"
+      },
+      {
+        "Description": "m365 spo cdn origin list --type Private",
+        "Example": "Show the list of origins configured for the Private CDN"
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams membersettings list",
+    "Description": "Lists member settings for a Microsoft Teams team",
+    "Options": "`-i, --teamId`: The ID of the team for which to get the member settings",
+    "Examples": [
+      {
+        "Description": "m365 teams membersettings list --teamId 2609af39-7775-4f94-a3dc-0dd67657e900",
+        "Example": "Get member settings for a Microsoft Teams team"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo feature list",
+    "Description": "Lists Features activated in the specified site or site collection",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site (collection) to retrieve the activated Features from`-s, --scope [scope]`: Scope of the Features to retrieve. Allowed values `Site,Web`. Default `Web`",
+    "Examples": [
+      {
+        "Description": "`-u, --webUrl <webUrl>`",
+        "Example": "Return details about Features activated in the specified site collection"
+      },
+      {
+        "Description": "`-s, --scope [scope]`",
+        "Example": ": URL of the site (collection) to retrieve the activated Features from"
+      },
+      {
+        "Description": "`-u, --webUrl <webUrl>`",
+        "Example": ": Scope of the Features to retrieve. Allowed values `Site,Web`. Default `Web`"
+      },
+      {
+        "Description": "",
+        "Example": ": URL of the site (collection) to retrieve the activated Features from"
+      },
+      {
+        "Description": ": Scope of the Features to retrieve. Allowed values `Site,Web`. Default `Web`",
+        "Example": "`-s, --scope [scope]`"
+      },
+      {
+        "Description": "Lists Features activated in the specified site or site collection",
+        "Example": "m365 spo feature list [options]"
+      },
+      {
+        "Description": "m365 spo feature list --webUrl https://contoso.sharepoint.com/sites/test --scope Web",
+        "Example": "import Global from '/docs/cmd/_global.mdx';"
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams chat message list",
+    "Description": "Lists all messages from a Microsoft Teams chat conversation.",
+    "Options": "`-i, --chatId <chatId>`: The ID of the chat conversation",
+    "Examples": [
+      {
+        "Description": "m365 teams chat message list --chatId 19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+        "Example": "List the messages from a Microsoft Teams chat conversation"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo page section get",
+    "Description": "Get information about the specified modern page section",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.`-n, --pageName <pageName>`: Name of the page to get section information of.`-s, --section <sectionId>`: ID of the section for which to retrieve information.",
+    "Examples": [
+      {
+        "Description": "m365 spo page section get --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx --section 1",
+        "Example": "Get information about the specified section of the modern page"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo file version get",
+    "Description": "Gets information about a specific version of a specified file",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located`--label <label>`: Label of version which will be retrieved`--fileUrl [fileUrl]`: The server- or site-relative decoded URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both`-i, --fileId [fileId]`: The UniqueId (GUID) of the file to retrieve. Specify either `fileUrl` or `fileId` but not both",
+    "Examples": [
+      {
+        "Description": "m365 spo file version get --webUrl https://contoso.sharepoint.com --label \"1.0\" --fileId 'b2307a39-e878-458b-bc90-03bc578531d6'",
+        "Example": "Get file version in a specific site based on fileId"
+      },
+      {
+        "Description": "m365 spo file version get --webUrl https://contoso.sharepoint.com --label \"1.0\" --fileUrl '/Shared Documents/Document.docx'",
+        "Example": "Get file in a specific site based on fileUrl"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo field get",
+    "Description": "Retrieves information about the specified list- or site column",
+    "Options": "`-u, --webUrl <webUrl>`: Absolute URL of the site where the field is located`-l, --listTitle [listTitle]`: Title of the list where the field is located. Specify only one of listTitle, listId or listUrl`--listId [listId]`: ID of the list where the field is located. Specify only one of listTitle, listId or listUrl`--listUrl [listUrl]`: Server- or web-relative URL of the list where the field is located. Specify only one of listTitle, listId or listUrl`-i, --id [id]`: The ID of the field to retrieve. Specify id or title but not both`-t, --title [title]`: The display name (case-sensitive) of the field to remove. Specify id or title, or group but not both",
+    "Examples": [
+      {
+        "Description": "`-u, --webUrl <webUrl>`: Absolute URL of the site where the field is located",
+        "Example": "Retrieves site column by id located in site https://contoso.sharepoint.com/sites/contoso-sales"
+      },
+      {
+        "Description": ": Title of the list where the field is located. Specify only one of listTitle, listId or listUrl",
+        "Example": "`-l, --listTitle [listTitle]`"
+      },
+      {
+        "Description": ": ID of the list where the field is located. Specify only one of listTitle, listId or listUrl",
+        "Example": "`--listId [listId]`"
+      },
+      {
+        "Description": ": Server- or web-relative URL of the list where the field is located. Specify only one of listTitle, listId or listUrl",
+        "Example": "`--listUrl [listUrl]`"
+      },
+      {
+        "Description": ": The ID of the field to retrieve. Specify id or title but not both",
+        "Example": "`-i, --id [id]`"
+      },
+      {
+        "Description": ": The display name (case-sensitive) of the field to remove. Specify id or title, or group but not both",
+        "Example": "`-t, --title [title]`"
+      },
+      {
+        "Description": ": Absolute URL of the site where the field is located",
+        "Example": "`-u, --webUrl <webUrl>`"
+      },
+      {
+        "Description": "`-l, --listTitle [listTitle]`",
+        "Example": ""
+      },
+      {
+        "Description": "",
+        "Example": ": Title of the list where the field is located. Specify only one of listTitle, listId or listUrl"
+      },
+      {
+        "Description": ": ID of the list where the field is located. Specify only one of listTitle, listId or listUrl",
+        "Example": "`--listId [listId]`"
+      },
+      {
+        "Description": "`--listUrl [listUrl]`",
+        "Example": ""
+      },
+      {
+        "Description": "",
+        "Example": ": Server- or web-relative URL of the list where the field is located. Specify only one of listTitle, listId or listUrl"
+      },
+      {
+        "Description": ": The ID of the field to retrieve. Specify id or title but not both",
+        "Example": "`-i, --id [id]`"
+      },
+      {
+        "Description": "`-t, --title [title]`",
+        "Example": ""
+      },
+      {
+        "Description": "m365 spo field get [options]",
+        "Example": ": The display name (case-sensitive) of the field to remove. Specify id or title, or group but not both"
+      },
+      {
+        "Description": "import Global from '/docs/cmd/_global.mdx';",
+        "Example": "Retrieves information about the specified list- or site column"
+      },
+      {
+        "Description": null,
+        "Example": "m365 spo field get --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listUrl \"Lists/Events\" --title \"Title\""
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams funsettings list",
+    "Description": "Lists fun settings for the specified Microsoft Teams team",
+    "Options": "`-i, --teamId <teamId>`: The ID of the team for which to list fun settings",
+    "Examples": [
+      {
+        "Description": "m365 teams funsettings list --teamId 83cece1e-938d-44a1-8b86-918cf6151957",
+        "Example": "List fun settings of a Microsoft Teams team"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo web retentionlabel list",
+    "Description": "Get a list of retention labels that are available on a site.",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site.",
+    "Examples": [
+      {
+        "Description": "m365 spo web retentionlabel list --webUrl 'https://contoso.sharepoint.com/sites/sales'",
+        "Example": "Get a list of retention labels for the Sales site"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo list webhook list",
+    "Description": "Lists all webhooks for the specified list",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list is located.`-i, --listId [listId]`: ID of the list. Specify either `listTitle`, `listId` or `listUrl`.`-t, --listTitle [listTitle]`: Title of the list. Specify either `listTitle`, `listId` or `listUrl`.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`.",
+    "Examples": [
+      {
+        "Description": "m365 spo list webhook list --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf",
+        "Example": "List all webhooks for a list with a specific ID in a specific site"
+      },
+      {
+        "Description": "m365 spo list webhook list --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle Documents",
+        "Example": "List all webhooks for a list with a specific title in a specific site"
+      },
+      {
+        "Description": "m365 spo list webhook list --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl '/sites/project-x/Documents'",
+        "Example": "List all webhooks for a list with a specific URL in a specific site"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo sitedesign list",
+    "Description": "Lists available site designs for creating modern sites",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo sitedesign list",
+        "Example": "List available site designs"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo file get",
+    "Description": "Gets information about the specified file",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located`--url [url]`: The server- or site-relative decoded URL of the file to retrieve. Specify either `url` or `id` but not both`-i, --id [id]`: The UniqueId (GUID) of the file to retrieve. Specify either `url` or `id` but not both`--asString`: Set to retrieve the contents of the specified file as string`--asListItem`: Set to retrieve the underlying list item`--asFile`: Set to save the file to the path specified in the path option`-p, --path [path]`: The local path where to save the retrieved file. Must be specified when the `--asFile` option is used`--withPermissions`: Set if you want to return associated roles and permissions",
+    "Examples": [
+      {
+        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6'",
+        "Example": "Get file properties for a file with id (UniqueId) parameter located in a site"
+      },
+      {
+        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --asString",
+        "Example": "Get contents of the file with id (UniqueId) parameter located in a site"
+      },
+      {
+        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --asListItem",
+        "Example": "Get list item properties for a file with id (UniqueId) parameter located in a site"
+      },
+      {
+        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --asFile --path /Users/user/documents/SavedAsTest1.docx",
+        "Example": "Saves the file with id (UniqueId) parameter located in a site to a local file"
+      },
+      {
+        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --url '/sites/project-x/documents/Test1.docx'",
+        "Example": "Return file properties for a file with server-relative url located in a site"
+      },
+      {
+        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --url '/sites/project-x/documents/Test1.docx' --asString",
+        "Example": "Returns a file as string for a file with server-relative url located in a site"
+      },
+      {
+        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --url '/sites/project-x/documents/Test1.docx' --asListItem",
+        "Example": "Returna the list item properties for a file with the server-relative url located in a site"
+      },
+      {
+        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --url '/sites/project-x/documents/Test1.docx' --asFile --path /Users/user/documents/SavedAsTest1.docx",
+        "Example": "Saves a file with the server-relative url located in a site to a local file"
+      },
+      {
+        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --withPermissions",
+        "Example": "Gets the file properties for a file with id (UniqueId) parameter located in a site with permissions"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo list get",
+    "Description": "Gets information about the specific list",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list to retrieve is located.`-i, --id [id]`: ID of the list to retrieve information for. Specify either `id`, `title`, or `url` but not multiple.`-t, --title [title]`: Title of the list to retrieve information for. Specify either `id`, `title`, or `url` but not multiple.`--url [url]`: Server- or site-relative URL of the list. Specify either `id`, `title`, or `url` but not multiple.`-p, --properties [properties]`: Comma-separated list of properties to retrieve from the list. Will retrieve all properties possible from default response, if not specified.`--withPermissions`: Set if you want to return associated roles and permissions of the list.",
+    "Examples": [
+      {
+        "Description": "m365 spo list get --id 0cd891ef-afce-4e55-b836-fce03286cccf --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Get information about a list with specified ID located in the specified site."
+      },
+      {
+        "Description": "m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Get information about a list with specified title located in the specified site."
+      },
+      {
+        "Description": "m365 spo list get --url 'sites/project-x/Documents' --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Get information about a list with specified server relative url located in the specified site."
+      },
+      {
+        "Description": "m365 spo list get --url 'Shared Documents' --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Get information about a list with specified site-relative URL located in the specified site."
+      },
+      {
+        "Description": "m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --properties \"Title,Id,HasUniqueRoleAssignments,AllowContentTypes\"",
+        "Example": "Get information about a list returning the specified list properties."
+      },
+      {
+        "Description": "m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --properties \"Title,Id,RootFolder/ServerRelativeUrl\"",
+        "Example": "Get information about a list returning the list Id, Title and ServerRelativeUrl properties."
+      },
+      {
+        "Description": "m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --withPermissions",
+        "Example": "Get information about a list along with the roles and permissions."
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams user list",
+    "Description": "Lists users for the specified Microsoft Teams team",
+    "Options": "`-i, --teamId <teamId>`: The ID of the Microsoft Teams team for which to list users.`-r, --role [role]`: Filter the results to only users with the given role: `Owner`, `Member`, `Guest`.",
+    "Examples": [
+      {
+        "Description": "m365 teams user list --teamId '00000000-0000-0000-0000-000000000000'",
+        "Example": "List all users and their role in the specified Microsoft teams team."
+      },
+      {
+        "Description": "m365 teams user list --teamId '00000000-0000-0000-0000-000000000000' --role Owner",
+        "Example": "List all owners and their role in the specified Microsoft teams team."
       }
     ]
   },
@@ -156,6 +1850,307 @@ export const Commands = [
       {
         "Description": "m365 spo web list --url https://contoso.sharepoint.com",
         "Example": "Return all subsites from site https://contoso.sharepoint.com/"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo sitescript list",
+    "Description": "Lists site script available for use with site designs",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo sitescript list",
+        "Example": "List all site scripts available for use with site designs"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo tenant commandset get",
+    "Description": "Get a ListView Command Set that is installed tenant wide",
+    "Options": "`-t, --title [title]`: The title of the ListView Command Set. Specify either `title`, `id`, or `clientSideComponentId`.`-i, --id [id]`: The id of the ListView Command Set. Specify either `title`, `id`, or `clientSideComponentId`.`-c, --clientSideComponentId  [clientSideComponentId]`: The Client Side Component Id (GUID) of the ListView Command Set. Specify either `title`, `id`, or `clientSideComponentId`.",
+    "Examples": [
+      {
+        "Description": "m365 spo tenant commandset get --title \"Some customizer\"",
+        "Example": "Retrieves a ListView Command Set by title."
+      },
+      {
+        "Description": "m365 spo tenant commandset get --id 3",
+        "Example": "Retrieves a ListView Command Set by id."
+      },
+      {
+        "Description": "m365 spo tenant commandset get --clientSideComponentId 7096cded-b83d-4eab-96f0-df477ed7c0bc",
+        "Example": "Retrieves a ListView Command Set by clientSideComponentId."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo page control get",
+    "Description": "Gets information about the specific control on a modern page",
+    "Options": "`-i, --id <id>`: ID of the control to retrieve information for.`-n, --pageName <pageName>`: Name of the page where the control is located.`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.",
+    "Examples": [
+      {
+        "Description": "m365 spo page control get --id 3ede60d3-dc2c-438b-b5bf-cc40bb2351e1 --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx",
+        "Example": "Get information about the control with ID 3ede60d3-dc2c-438b-b5bf-cc40bb2351e1 placed on a modern page with name home.aspx"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo commandset get",
+    "Description": "Get a ListView Command Set that is added to a site.",
+    "Options": "`-u, --webUrl <webUrl>`: Url of the site.`-t, --title [title]`: The title of the ListView Command Set. Specify either `title`, `id` or `clientSideComponentId`.`-i, --id [id]`: The id of the ListView Command Set. Specify either `title`, `id` or `clientSideComponentId`.`-c, --clientSideComponentId [clientSideComponentId]`: The id of the ListView Command Set. Specify either `title`, `id` or `clientSideComponentId`.`-s, --scope [scope]`: Scope of the ListView Command Set. Allowed values: `Site`, `Web`, `All`. Defaults to `All`.",
+    "Examples": [
+      {
+        "Description": "m365 spo commandset get --title \"Some customizer\" --webUrl https://contoso.sharepoint.com/sites/sales",
+        "Example": "Retrieves a ListView Command Set by title."
+      },
+      {
+        "Description": "m365 spo commandset get --id 14125658-a9bc-4ddf-9c75-1b5767c9a337 --webUrl https://contoso.sharepoint.com/sites/sales -scope Web",
+        "Example": "Retrieves a ListView Command Set by id with scope 'Web'."
+      },
+      {
+        "Description": "m365 spo commandset get --clientSideComponentId c1cbd896-5140-428d-8b0c-4873be19f5ac --webUrl https://contoso.sharepoint.com/sites/sales --scope Site",
+        "Example": "Retrieves a ListView Command Set by clientSideComponentId with scope 'Site'."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo commandset list",
+    "Description": "Get a list of ListView Command Sets that are added to a site.",
+    "Options": "`-u, --webUrl <webUrl>`: The url of the site.`-s, --scope [scope]`: Scope of the ListView Command Sets. Allowed values `Site`, `Web`, `All`. Default to `All`",
+    "Examples": [
+      {
+        "Description": "m365 spo commandset list --webUrl https://contoso.sharepoint.com/sites/sales",
+        "Example": "Retrieves a list of ListView Command Sets."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo sitedesign run list",
+    "Description": "Lists information about site designs applied to the specified site",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site for which to list applied site designs`-i, --siteDesignId [siteDesignId]`: The ID of the site design for which to display information",
+    "Examples": [
+      {
+        "Description": "m365 spo sitedesign run list --webUrl https://contoso.sharepoint.com/sites/team-a",
+        "Example": "List site designs applied to the specified site"
+      },
+      {
+        "Description": "m365 spo sitedesign run list --webUrl https://contoso.sharepoint.com/sites/team-a --siteDesignId 6ec3ca5b-d04b-4381-b169-61378556d76e",
+        "Example": "List information about the specified site design applied to the specified site"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo cdn get",
+    "Description": "View current status of the specified Microsoft 365 CDN",
+    "Options": "`-t, --type [type]`: Type of CDN to manage. Allowed values `Public`, `Private`. Default `Public`.",
+    "Examples": [
+      {
+        "Description": "m365 spo cdn get",
+        "Example": "Show if the Public CDN is currently enabled or not."
+      },
+      {
+        "Description": "m365 spo cdn get --type Private",
+        "Example": "Show if the Private CDN is currently enabled or not."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo applicationcustomizer list",
+    "Description": "Get a list of application customizers that are added to a site.",
+    "Options": "`-u, --webUrl <webUrl>`: The url of the site.`-s, --scope [scope]`: Scope of the application customizers. Allowed values `Site`, `Web`, `All`. Defaults to `All`",
+    "Examples": [
+      {
+        "Description": "m365 spo applicationcustomizer list --webUrl https://contoso.sharepoint.com/sites/sales",
+        "Example": "Retrieves a list of application customizers."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo tenant commandset list",
+    "Description": "Retrieves a list of ListView Command Sets that are installed tenant-wide",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo tenant commandset list",
+        "Example": "Retrieves a list of ListView Command Sets."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo list webhook get",
+    "Description": "Gets information about the specific webhook",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list is located.`-l, --listId [listId]`: ID of the list. Specify either `listTitle`, `listId` or `listUrl`.`-t, --listTitle [listTitle]`: Title of the list. Specify either `listTitle`, `listId` or `listUrl`.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`.`-i, --id <id>`: ID of the webhook.",
+    "Examples": [
+      {
+        "Description": "m365 spo list webhook get --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf --id cc27a922-8224-4296-90a5-ebbc54da2e85",
+        "Example": "Return information about a specific webhook which belongs to a list retrieved by ID in a specific site"
+      },
+      {
+        "Description": "m365 spo list webhook get --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle Documents --id cc27a922-8224-4296-90a5-ebbc54da2e85",
+        "Example": "Return information about a specific webhook which belongs to a list retrieved by Title in a specific site"
+      },
+      {
+        "Description": "m365 spo list webhook get --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl '/sites/project-x/Documents' --id cc27a922-8224-4296-90a5-ebbc54da2e85",
+        "Example": "Return information about a specific webhook which belongs to a list retrieved by URL in a specific site"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo list view get",
+    "Description": "Gets information about specific list view",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list is located`--listId [listId]`: ID of the list where the view is located. Specify only one of `listTitle`, `listId` or `listUrl``--listTitle [listTitle]`: Title of the list where the view is located. Specify only one of `listTitle`, `listId` or `listUrl``--listUrl [listUrl]`: Server- or web-relative URL of the list where the view is located. Specify only one of `listTitle`, `listId` or `listUrl``--id [id]`: ID of the view to get. Specify `title` or `id` but not both`--title [title]`: Title of the view to get. Specify `title` or `id` but not both",
+    "Examples": [
+      {
+        "Description": "m365 spo list view get --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'My List' --title 'All Items'",
+        "Example": "Gets a list view by name from a list located in site https://contoso.sharepoint.com/sites/project-x"
+      },
+      {
+        "Description": "m365 spo list view get --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Lists/My List' --id 330f29c5-5c4c-465f-9f4b-7903020ae1ce",
+        "Example": "Gets a list view by ID from a list located in site https://contoso.sharepoint.com/sites/project-x"
+      },
+      {
+        "Description": "m365 spo list view get --webUrl https://contoso.sharepoint.com/sites/project-x --listId 330f29c5-5c4c-465f-9f4b-7903020ae1c1 --title 'All Items'",
+        "Example": "Gets a list view by name from a list located in site https://contoso.sharepoint.com/sites/project-x. Retrieve the list by its ID"
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams user app list",
+    "Description": "List the apps installed in the personal scope of the specified user",
+    "Options": "`--userId [userId]`: The ID of the user to get the apps from. Specify `userId` or `userName` but not both.`--userName [userName]`: The UPN of the user to get the apps from. Specify `userId` or `userName` but not both.",
+    "Examples": [
+      {
+        "Description": "m365 teams user app list --userId 4440558e-8c73-4597-abc7-3644a64c4bce",
+        "Example": "List the apps installed in the personal scope of the specified user using its ID."
+      },
+      {
+        "Description": "m365 teams user app list --userName admin@contoso.com",
+        "Example": "List the apps installed in the personal scope of the specified user using its UPN."
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams meeting get",
+    "Description": "Get specified meeting details",
+    "Options": "`-u, --userId [userId]`: The id of the user, omit to retrieve meetings for current signed in user. Use either `id`, `userName`, or `email`, but not multiple.`-n, --userName [userName]`: The name of the user, omit to retrieve meetings for current signed in user. Use either `id`, `userName`, or `email`, but not multiple.`--email [email]`: The email of the user, omit to retrieve meetings for current signed in user. Use either `id`, `userName`, or `email`, but not multiple.`-j, --joinUrl <joinUrl>`: The join URL from a calendar invite.",
+    "Examples": [
+      {
+        "Description": "m365 teams meeting get --userId 00000000-0000-0000-0000-000000000000 --joinUrl 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_MGQ4MDQyNTEtNTQ2NS00YjQxLTlkM2EtZWVkODYxODYzMmY2%40thread.v2/0?context=%7b%22Tid%22%3a%22909c6581-5130-43e9-88f3-fcb3582cde37%22%2c%22Oid%22%3a%22dc17674c-81d9-4adb-bfb2-8f6a442e4622%22%7d'",
+        "Example": "Retrieve meeting details for given meeting with userId and joinurl"
+      },
+      {
+        "Description": "m365 teams meeting get --userName 'user@tenant.com' --joinUrl 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_MGQ4MDQyNTEtNTQ2NS00YjQxLTlkM2EtZWVkODYxODYzMmY2%40thread.v2/0?context=%7b%22Tid%22%3a%22909c6581-5130-43e9-88f3-fcb3582cde37%22%2c%22Oid%22%3a%22dc17674c-81d9-4adb-bfb2-8f6a442e4622%22%7d'",
+        "Example": "Retrieve meeting details for given meeting with userName and joinurl"
+      },
+      {
+        "Description": "m365 teams meeting get --email 'user@tenant.com' --joinUrl 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_MGQ4MDQyNTEtNTQ2NS00YjQxLTlkM2EtZWVkODYxODYzMmY2%40thread.v2/0?context=%7b%22Tid%22%3a%22909c6581-5130-43e9-88f3-fcb3582cde37%22%2c%22Oid%22%3a%22dc17674c-81d9-4adb-bfb2-8f6a442e4622%22%7d'",
+        "Example": "Retrieve meeting details for given meeting with email and joinurl"
+      },
+      {
+        "Description": "m365 teams meeting get --joinUrl 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_MGQ4MDQyNTEtNTQ2NS00YjQxLTlkM2EtZWVkODYxODYzMmY2%40thread.v2/0?context=%7b%22Tid%22%3a%22909c6581-5130-43e9-88f3-fcb3582cde37%22%2c%22Oid%22%3a%22dc17674c-81d9-4adb-bfb2-8f6a442e4622%22%7d'",
+        "Example": "Retrieve meeting details of the currently logged in user with joinurl"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo list retentionlabel get",
+    "Description": "Gets the default retention label set on the specified list or library.",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list to get the label from is located.`-l, --listId [listId]`: ID of the list to get the label from. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.`-t, --listTitle [listTitle]`: Title of the list to get the label from. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.",
+    "Examples": [
+      {
+        "Description": "m365 spo list retentionlabel get --listTitle ContosoList --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Gets retention label set on the list with specified title located in the specified site."
+      },
+      {
+        "Description": "m365 spo list retentionlabel get --listId cc27a922-8224-4296-90a5-ebbc54da2e85 --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Gets retention label set on the list with specified id located in the specified site."
+      },
+      {
+        "Description": "m365 spo list retentionlabel get --listUrl 'sites/project-x/Documents' --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Gets retention label set on the list with specified server relative url located in the specified site."
+      },
+      {
+        "Description": "m365 spo list retentionlabel get --listUrl 'Shared Documents' --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Gets retention label set on the list with specified site-relative URL located in the specified site."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo hidedefaultthemes get",
+    "Description": "Gets the current value of the HideDefaultThemes setting",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo hidedefaultthemes get",
+        "Example": "Get the current value of the HideDefaultThemes setting"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo contenttype list",
+    "Description": "Lists content types from specified site",
+    "Options": "`-u, --webUrl <webUrl>`: Absolute URL of the site for which to list content types`-c, --category [category]`: Category name of content types. When defined will return only content types from specified category",
+    "Examples": [
+      {
+        "Description": "`-u, --webUrl <webUrl>`",
+        "Example": "Retrieve site content types"
+      },
+      {
+        "Description": "`-c, --category [category]`",
+        "Example": ": Absolute URL of the site for which to list content types"
+      },
+      {
+        "Description": "`-u, --webUrl <webUrl>`",
+        "Example": ": Category name of content types. When defined will return only content types from specified category"
+      },
+      {
+        "Description": "",
+        "Example": ": Absolute URL of the site for which to list content types"
+      },
+      {
+        "Description": ": Category name of content types. When defined will return only content types from specified category",
+        "Example": "`-c, --category [category]`"
+      },
+      {
+        "Description": "Lists content types from specified site",
+        "Example": "m365 spo contenttype list [options]"
+      },
+      {
+        "Description": "m365 spo contenttype list --webUrl \"https://contoso.sharepoint.com/sites/contoso-sales\" --category \"List Content Types\"",
+        "Example": "import Global from '/docs/cmd/_global.mdx';"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo tenant appcatalogurl get",
+    "Description": "Gets the URL of the tenant app catalog",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo tenant appcatalogurl get",
+        "Example": "Get the URL of the tenant app catalog"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo tenant recyclebinitem list",
+    "Description": "Returns all modern and classic site collections in the tenant scoped recycle bin",
+    "Options": null,
+    "Examples": [
+      {
+        "Description": "m365 spo tenant recyclebinitem list",
+        "Example": "Returns all modern and classic site collections in the tenant scoped recycle bin"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo page column list",
+    "Description": "Lists columns in the specific section of a modern page",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.`-n, --pageName <pageName>`: Name of the page to list columns of.`-s, --section <sectionId>`: ID of the section for which to list columns.",
+    "Examples": [
+      {
+        "Description": "m365 spo page column list --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx --section 1",
+        "Example": "List columns in the first section of a modern page"
       }
     ]
   },
@@ -191,17 +2186,70 @@ export const Commands = [
     ]
   },
   {
-    "Command": "m365 spo app list",
-    "Description": "Lists apps from the specified app catalog",
-    "Options": "`-s, --appCatalogScope [appCatalogScope]`: Target app catalog. `tenant,sitecollection`. Default `tenant``-u, --appCatalogUrl [appCatalogUrl]`: URL of the tenant or site collection app catalog. It must be specified when the scope is `sitecollection`",
+    "Command": "m365 spo storageentity list",
+    "Description": "Lists tenant properties stored on the specified SharePoint Online app catalog",
+    "Options": "`-u, --appCatalogUrl <appCatalogUrl>`: URL of the app catalog site",
     "Examples": [
       {
-        "Description": "m365 spo app list",
-        "Example": "Return the list of available apps from the tenant app catalog. Show the installed version in the site if applicable."
+        "Description": "m365 spo storageentity list -u https://contoso.sharepoint.com/sites/appcatalog",
+        "Example": "List all tenant properties stored in the https://contoso.sharepoint.com/sites/appcatalog app catalog site"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo list contenttype list",
+    "Description": "Lists content types configured on the list",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list is located.`-l, --listId [listId]`: ID of the list. Specify either `listTitle`, `listId`, or `listUrl`.`-t, --listTitle [listTitle]`: Title of the list. Specify either `listTitle`, `listId`, or `listUrl`.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listTitle`, `listId`, or `listUrl`.",
+    "Examples": [
+      {
+        "Description": "m365 spo list contenttype list --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf",
+        "Example": "List all content types configured on a specific list retrieved by id in a specific site."
       },
       {
-        "Description": "m365 spo app list --appCatalogScope sitecollection --appCatalogUrl https://contoso.sharepoint.com/sites/site1",
-        "Example": "Return the list of available apps from a site collection app catalog of site https://contoso.sharepoint.com/sites/site1."
+        "Description": "m365 spo list contenttype list --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle Documents",
+        "Example": "List all content types configured on a specific list retrieved by title in a specific site."
+      },
+      {
+        "Description": "m365 spo list contenttype list --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'sites/project-x/Documents'",
+        "Example": "List all content types configured on a specific list retrieved by server relative URL in a specific site."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo file list",
+    "Description": "Gets all files within the specified folder and site",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the folder from which to retrieve files is located.`--folderUrl <folderUrl>`: The server- or site-relative decoded URL of the parent folder from which to retrieve files.`--fields [fields]`: Comma-separated list of fields to retrieve. Will retrieve all fields if not specified.`--filter [filter]`: OData filter to use to query the list of items with.`-r, --recursive`: Set to retrieve files from subfolders.",
+    "Examples": [
+      {
+        "Description": "m365 spo file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents'",
+        "Example": "Return all files from a folder"
+      },
+      {
+        "Description": "m365 spo file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents' --recursive",
+        "Example": "Return all files from a folder and all the sub-folders"
+      },
+      {
+        "Description": "m365 spo file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents' --fields \"Title,Length\"",
+        "Example": "Return the files from a folder with specific fields which will be expanded"
+      },
+      {
+        "Description": "m365 spo file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents' --fields ListItemAllFields/Id --filter \"Name eq 'document.docx'\"",
+        "Example": "Return the files from a folder that meet the criteria of the filter with specific fields which will be expanded"
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams meeting list",
+    "Description": "Retrieve all online meetings for a given user or shared mailbox",
+    "Options": "`--startDateTime <startDateTime>`: Time indicating the **inclusive** start of a time range of content to return.`--endDateTime [endDateTime]`: Time indicating the **exclusive** end of a time range of content to return.`--isOrganizer`: Set to retrieve only meetings the user is organizer for.`-u, --userId [userId]`: The id of the user or shared mailbox, omit to retrieve meetings for current signed in user. Use either `id`, `userName` or `email`, but not multiple. Use only when using application permissions.`-n, --userName [userName]`: The name of the user or shared mailbox, omit to retrieve meetings for current signed in user. Use either `id`, `userName` or `email`, but not multiple. Use only when using application permissions.`--email [email]`: The email of the user or shared mailbox, omit to retrieve meetings for current signed in user. Use either `id`, `userName` or `email`, but not multiple. Use only when using application permissions.",
+    "Examples": [
+      {
+        "Description": "m365 teams meeting list --startDateTime '2022-01-01T10:00:00Z' --endDateTime '2022-03-31T23:59:59Z'",
+        "Example": "List all meetings of the currently logged in user between two specific dates"
+      },
+      {
+        "Description": "m365 teams meeting list --startDateTime '2022-01-01T10:00:00Z' --email user@tenant.com --isOrganizer",
+        "Example": "List all meetings for a specific user retrieved by email of which the user is an organizer using application permissions"
       }
     ]
   },
@@ -285,498 +2333,6 @@ export const Commands = [
     ]
   },
   {
-    "Command": "m365 spo storageentity list",
-    "Description": "Lists tenant properties stored on the specified SharePoint Online app catalog",
-    "Options": "`-u, --appCatalogUrl <appCatalogUrl>`: URL of the app catalog site",
-    "Examples": [
-      {
-        "Description": "m365 spo storageentity list -u https://contoso.sharepoint.com/sites/appcatalog",
-        "Example": "List all tenant properties stored in the https://contoso.sharepoint.com/sites/appcatalog app catalog site"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo site get",
-    "Description": "Gets information about the specific site collection",
-    "Options": "`-u, --url <url>`: URL of the site collection to retrieve information for",
-    "Examples": [
-      {
-        "Description": "m365 spo site get -u https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Return information about the https://contoso.sharepoint.com/sites/project-x site collection."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo web installedlanguage list",
-    "Description": "Lists all installed languages on site",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site for which to retrieve the list of installed languages",
-    "Examples": [
-      {
-        "Description": "m365 spo web installedlanguage list --webUrl https://contoso.sharepoint.com",
-        "Example": "Return all installed languages from site https://contoso.sharepoint.com/"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo field list",
-    "Description": "Retrieves columns for the specified list or site",
-    "Options": "`-u, --webUrl <webUrl>`: Absolute URL of the site where fields are located`-t, --listTitle [listTitle]`: Title of the list where fields are located. Specify `listTitle`, `listId` or `listUrl``-i --listId [listId]`: ID of the list where fields are located. Specify `listTitle`, `listId` or `listUrl``--listUrl [listUrl]`: Server- or web-relative URL of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`",
-    "Examples": [
-      {
-        "Description": "`-u, --webUrl <webUrl>`: Absolute URL of the site where fields are located",
-        "Example": "Retrieves site columns for site https://contoso.sharepoint.com/sites/contoso-sales."
-      },
-      {
-        "Description": ": Title of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`",
-        "Example": "`-t, --listTitle [listTitle]`"
-      },
-      {
-        "Description": ": ID of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`",
-        "Example": "`-i --listId [listId]`"
-      },
-      {
-        "Description": ": Server- or web-relative URL of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`",
-        "Example": "`--listUrl [listUrl]`"
-      },
-      {
-        "Description": ": Absolute URL of the site where fields are located",
-        "Example": "`-u, --webUrl <webUrl>`"
-      },
-      {
-        "Description": "`-t, --listTitle [listTitle]`",
-        "Example": ""
-      },
-      {
-        "Description": "",
-        "Example": ": Title of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`"
-      },
-      {
-        "Description": ": ID of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`",
-        "Example": "`-i --listId [listId]`"
-      },
-      {
-        "Description": "`--listUrl [listUrl]`",
-        "Example": ""
-      },
-      {
-        "Description": "m365 spo field list [options]",
-        "Example": ": Server- or web-relative URL of the list where fields are located. Specify `listTitle`, `listId` or `listUrl`"
-      },
-      {
-        "Description": "import Global from '/docs/cmd/_global.mdx';",
-        "Example": "Retrieves columns for the specified list or site"
-      },
-      {
-        "Description": null,
-        "Example": "m365 spo field list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listUrl '/sites/contoso-sales/lists/Events'"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo list sitescript get",
-    "Description": "Extracts a site script from a SharePoint list",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list to extract the site script from is located.`-l, --listId [listId]`: ID of the list to extract the site script from. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.`-t, --listTitle [listTitle]`: Title of the list to extract the site script from. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.",
-    "Examples": [
-      {
-        "Description": "m365 spo list sitescript get --listTitle ContosoList --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Extract a site script from an existing SharePoint list with specified title located in the specified site."
-      },
-      {
-        "Description": "m365 spo list sitescript get --listId cc27a922-8224-4296-90a5-ebbc54da2e85 --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Extract a site script from an existing SharePoint list with specified id located in the specified site."
-      },
-      {
-        "Description": "m365 spo list sitescript get --listUrl 'sites/project-x/Documents' --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Extract a site script from an existing SharePoint list with specified server relative url located in the specified site."
-      },
-      {
-        "Description": "m365 spo list sitescript get --listUrl 'Shared Documents' --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Extract a site script from an existing SharePoint list with specified site-relative URL located in the specified site."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo tenant commandset get",
-    "Description": "Get a ListView Command Set that is installed tenant wide",
-    "Options": "`-t, --title [title]`: The title of the ListView Command Set. Specify either `title`, `id`, or `clientSideComponentId`.`-i, --id [id]`: The id of the ListView Command Set. Specify either `title`, `id`, or `clientSideComponentId`.`-c, --clientSideComponentId  [clientSideComponentId]`: The Client Side Component Id (GUID) of the ListView Command Set. Specify either `title`, `id`, or `clientSideComponentId`.",
-    "Examples": [
-      {
-        "Description": "m365 spo tenant commandset get --title \"Some customizer\"",
-        "Example": "Retrieves a ListView Command Set by title."
-      },
-      {
-        "Description": "m365 spo tenant commandset get --id 3",
-        "Example": "Retrieves a ListView Command Set by id."
-      },
-      {
-        "Description": "m365 spo tenant commandset get --clientSideComponentId 7096cded-b83d-4eab-96f0-df477ed7c0bc",
-        "Example": "Retrieves a ListView Command Set by clientSideComponentId."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo site list",
-    "Description": "Lists modern sites of the given type",
-    "Options": "`-t, --type [type]`: convenience option for type of sites to list. Allowed values are `TeamSite,CommunicationSite`.`--webTemplate [webTemplate]`: type of sites to list. To be used with values like `GROUP#0` and `SITEPAGEPUBLISHING#0`. Specify either `type` or `webTemplate`, but not both.  `--filter [filter]`: filter to apply when retrieving sites`--includeOneDriveSites`: use this switch to include OneDrive sites in the result when retrieving sites. Do not specify the `type` or `webTemplate` options when using this.",
-    "Examples": [
-      {
-        "Description": "m365 spo site list",
-        "Example": "List all sites in the currently connected tenant"
-      },
-      {
-        "Description": "m365 spo site list --type TeamSite",
-        "Example": "List all group connected team sites in the currently connected tenant"
-      },
-      {
-        "Description": "m365 spo site list --type CommunicationSite",
-        "Example": "List all communication sites in the currently connected tenant"
-      },
-      {
-        "Description": "m365 spo site list --type TeamSite --filter \"Url -like 'project'\"",
-        "Example": "List all group connected team sites that contain project in the URL"
-      },
-      {
-        "Description": "m365 spo site list --includeOneDriveSites",
-        "Example": "List all sites in the currently connected tenant including OneDrive sites"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo storageentity get",
-    "Description": "Get details for the specified tenant property",
-    "Options": "`-k, --key <key>`: Name of the tenant property to retrieve",
-    "Examples": [
-      {
-        "Description": "m365 spo storageentity get -k AnalyticsId",
-        "Example": "Show the value, description and comment of the AnalyticsId tenant property"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo cdn policy list",
-    "Description": "Lists CDN policies settings for the current SharePoint Online tenant",
-    "Options": "`-t, --cdnType [cdnType]`: Type of CDN to manage. `Public,Private`. Default `Public`",
-    "Examples": [
-      {
-        "Description": "m365 spo cdn policy list",
-        "Example": "Show the list of policies configured for the Public CDN"
-      },
-      {
-        "Description": "m365 spo cdn policy list --cdnType Private",
-        "Example": "Show the list of policies configured for the Private CDN"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo web get",
-    "Description": "Retrieve information about the specified site",
-    "Options": "`-u, --url <url>`: URL of the site for which to retrieve the information`--withGroups`: Set if you want to return associated groups (associatedOwnerGroup, associatedMemberGroup and associatedVisitorGroup) along with other properties`--withPermissions`: Set if you want to return associated roles and permissions",
-    "Examples": [
-      {
-        "Description": "m365 spo web get --url https://contoso.sharepoint.com/subsite",
-        "Example": "Retrieve information about a site"
-      },
-      {
-        "Description": "m365 spo web get --url https://contoso.sharepoint.com/subsite --withGroups",
-        "Example": "Retrieve information about a site along with associated groups for the web"
-      },
-      {
-        "Description": "m365 spo web get --url https://contoso.sharepoint.com/subsite --withPermissions",
-        "Example": "Retrieve information about a site along with the RoleAssignments for the web"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo sitedesign list",
-    "Description": "Lists available site designs for creating modern sites",
-    "Options": null,
-    "Examples": [
-      {
-        "Description": "m365 spo sitedesign list",
-        "Example": "List available site designs"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo term list",
-    "Description": "Lists taxonomy terms from the given term set",
-    "Options": "`-u, --webUrl [webUrl]`: If specified, allows you to list terms from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.`--termGroupId [termGroupId]`: ID of the term group where the term set is located. Specify `termGroupId` or `termGroupName` but not both.`--termGroupName [termGroupName]`: Name of the term group where the term set is located. Specify `termGroupId` or `termGroupName` but not both.`--termSetId [termSetId]`: ID of the term set for which to retrieve terms. Specify `termSetId` or `termSetName` but not both.`--termSetName [termSetName]`: Name of the term set for which to retrieve terms. Specify `termSetId` or `termSetName` but not both.`--includeChildTerms`: If specified, child terms are loaded as well.",
-    "Examples": [
-      {
-        "Description": "m365 spo term list --webUrl https://contoso.sharepoint.com/sites/project-x --termGroupName PnPTermSets --termSetName PnP-Organizations",
-        "Example": "List taxonomy terms from the specified sitecollection, the term group and term set with the given name"
-      },
-      {
-        "Description": "m365 spo term list --termGroupName PnPTermSets --termSetName PnP-Organizations",
-        "Example": "List taxonomy terms from the term group and term set with the given name."
-      },
-      {
-        "Description": "m365 spo term list --termGroupId 0e8f395e-ff58-4d45-9ff7-e331ab728beb --termSetId 0e8f395e-ff58-4d45-9ff7-e331ab728bec",
-        "Example": "List taxonomy terms from the term group and term set with the given ID."
-      },
-      {
-        "Description": "m365 spo term list --termGroupId 0e8f395e-ff58-4d45-9ff7-e331ab728beb --termSetId 0e8f395e-ff58-4d45-9ff7-e331ab728bec --includeChildTerms",
-        "Example": "List taxonomy terms from the term group and term set with the given ID including child terms if any are found."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo term group get",
-    "Description": "Gets information about the specified taxonomy term group",
-    "Options": "`-u, --webUrl [webUrl]`: If specified, allows you to get a term group from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.`-i, --id [id]`: ID of the term group to retrieve. Specify `name` or `id` but not both.`-n, --name [name]`: Name of the term group to retrieve. Specify `name` or `id` but not both.",
-    "Examples": [
-      {
-        "Description": "m365 spo term group get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb",
-        "Example": "Get information about a taxonomy term group using its ID."
-      },
-      {
-        "Description": "m365 spo term group get --name PnPTermSets",
-        "Example": "Get information about a taxonomy term group using its name."
-      },
-      {
-        "Description": "m365 spo term group get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Get information about a taxonomy term group from the specified sitecollection using its ID."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo eventreceiver get",
-    "Description": "Retrieves specific event receiver for the specified web, site or list by event receiver name or id.",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the web for which to retrieve the event receivers.`--listTitle [listTitle]`: The title of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.`--listId [listId]`: The id of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.`--listUrl [listUrl]`: The url of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.`-n, --name [name]`: The name of the event receiver to retrieve. Specify either `name` or `id` but not both.`-i, --id [id]`: The id of the event receiver to retrieve. Specify either `name` or `id` but not both.`-s, --scope [scope]`: The scope of which to retrieve the event receivers. Can be either `site` or `web`. Defaults to `web`. Only applicable when not specifying any of the list properties.",
-    "Examples": [
-      {
-        "Description": "m365 spo eventreceiver list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --name 'PnP Test Receiver'",
-        "Example": "Retrieve event receivers in web https://contoso.sharepoint.com/sites/contoso-sales with name PnP Test Receiver."
-      },
-      {
-        "Description": "m365 spo eventreceiver list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --scope site --id c5a6444a-9c7f-4a0d-9e29-fc6fe30e34ec",
-        "Example": "Retrieve event receivers in site https://contoso.sharepoint.com/sites/contoso-sales with id c5a6444a-9c7f-4a0d-9e29-fc6fe30e34ec."
-      },
-      {
-        "Description": "m365 spo eventreceiver list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listTitle Events --name 'PnP Test Receiver'",
-        "Example": "Retrieve event receivers for list with title Events in web https://contoso.sharepoint.com/sites/contoso-sales with name PnP Test Receiver."
-      },
-      {
-        "Description": "m365 spo eventreceiver list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listId '202b8199-b9de-43fd-9737-7f213f51c991' --id c5a6444a-9c7f-4a0d-9e29-fc6fe30e34ec",
-        "Example": "Retrieve event receivers for list with ID 202b8199-b9de-43fd-9737-7f213f51c991 in web https://contoso.sharepoint.com/sites/contoso-sales with id c5a6444a-9c7f-4a0d-9e29-fc6fe30e34ec."
-      },
-      {
-        "Description": "m365 spo eventreceiver list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listUrl '/sites/contoso-sales/lists/Events' --name 'PnP Test Receiver'",
-        "Example": "Retrieve event receivers for list with url /sites/contoso-sales/lists/Events in web https://contoso.sharepoint.com/sites/contoso-sales with name PnP Test Receiver."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo tenant commandset list",
-    "Description": "Retrieves a list of ListView Command Sets that are installed tenant-wide",
-    "Options": null,
-    "Examples": [
-      {
-        "Description": "m365 spo tenant commandset list",
-        "Example": "Retrieves a list of ListView Command Sets."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo user get",
-    "Description": "Gets a site user within specific web",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the web to get the user within`-i, --id [id]`: ID of the user to retrieve information for. Use either `email`, `id` or `loginName`, but not all.`--email [email]`: Email of the user to retrieve information for. Use either `email`, `id` or `loginName`, but not all.`--loginName [loginName]`: Login name of the user to retrieve information for. Use either `email`, `id` or `loginName`, but not all.",
-    "Examples": [
-      {
-        "Description": "m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --email john.doe@mytenant.onmicrosoft.com",
-        "Example": "Get user by email for a web"
-      },
-      {
-        "Description": "m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --id 6",
-        "Example": "Get user by ID for a web"
-      },
-      {
-        "Description": "m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --loginName \"i:0#.f|membership|john.doe@mytenant.onmicrosoft.com\"",
-        "Example": "Get user by login name for a web"
-      },
-      {
-        "Description": "m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Get the currently logged-in user"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo customaction list",
-    "Description": "Lists user custom actions for site or site collection",
-    "Options": "`-u, --webUrl <webUrl>`: Url of the site or site collection to retrieve the custom action from`-s, --scope [scope]`: Scope of the custom action. Allowed values `Site`, `Web`, `All`. Default `All`",
-    "Examples": [
-      {
-        "Description": "m365 spo customaction list --webUrl https://contoso.sharepoint.com/sites/test",
-        "Example": "Return details about all user custom actions located in site or site collection https://contoso.sharepoint.com/sites/test"
-      },
-      {
-        "Description": "m365 spo customaction list --webUrl https://contoso.sharepoint.com/sites/test --scope Site",
-        "Example": "Return details about all user custom actions located in site collection https://contoso.sharepoint.com/sites/test"
-      },
-      {
-        "Description": "m365 spo customaction list --webUrl https://contoso.sharepoint.com/sites/test --scope Web",
-        "Example": "Return details about all user custom actions located in site https://contoso.sharepoint.com/sites/test"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo tenant settings list",
-    "Description": "Lists the global tenant settings",
-    "Options": null,
-    "Examples": [
-      {
-        "Description": "m365 spo tenant settings list",
-        "Example": "Lists the settings of the tenant"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo roledefinition get",
-    "Description": "Gets specified role definition from web",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site for which to retrieve the role definition.`-i, --id <id>`: The Id of the role definition to retrieve.",
-    "Examples": [
-      {
-        "Description": "m365 spo roledefinition get --webUrl https://contoso.sharepoint.com/sites/project-x --id 1",
-        "Example": "Retrieve the role definition for the given site"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo field get",
-    "Description": "Retrieves information about the specified list- or site column",
-    "Options": "`-u, --webUrl <webUrl>`: Absolute URL of the site where the field is located`-l, --listTitle [listTitle]`: Title of the list where the field is located. Specify only one of listTitle, listId or listUrl`--listId [listId]`: ID of the list where the field is located. Specify only one of listTitle, listId or listUrl`--listUrl [listUrl]`: Server- or web-relative URL of the list where the field is located. Specify only one of listTitle, listId or listUrl`-i, --id [id]`: The ID of the field to retrieve. Specify id or title but not both`-t, --title [title]`: The display name (case-sensitive) of the field to remove. Specify id or title, or group but not both",
-    "Examples": [
-      {
-        "Description": "`-u, --webUrl <webUrl>`: Absolute URL of the site where the field is located",
-        "Example": "Retrieves site column by id located in site https://contoso.sharepoint.com/sites/contoso-sales"
-      },
-      {
-        "Description": ": Title of the list where the field is located. Specify only one of listTitle, listId or listUrl",
-        "Example": "`-l, --listTitle [listTitle]`"
-      },
-      {
-        "Description": ": ID of the list where the field is located. Specify only one of listTitle, listId or listUrl",
-        "Example": "`--listId [listId]`"
-      },
-      {
-        "Description": ": Server- or web-relative URL of the list where the field is located. Specify only one of listTitle, listId or listUrl",
-        "Example": "`--listUrl [listUrl]`"
-      },
-      {
-        "Description": ": The ID of the field to retrieve. Specify id or title but not both",
-        "Example": "`-i, --id [id]`"
-      },
-      {
-        "Description": ": The display name (case-sensitive) of the field to remove. Specify id or title, or group but not both",
-        "Example": "`-t, --title [title]`"
-      },
-      {
-        "Description": ": Absolute URL of the site where the field is located",
-        "Example": "`-u, --webUrl <webUrl>`"
-      },
-      {
-        "Description": "`-l, --listTitle [listTitle]`",
-        "Example": ""
-      },
-      {
-        "Description": "",
-        "Example": ": Title of the list where the field is located. Specify only one of listTitle, listId or listUrl"
-      },
-      {
-        "Description": ": ID of the list where the field is located. Specify only one of listTitle, listId or listUrl",
-        "Example": "`--listId [listId]`"
-      },
-      {
-        "Description": "`--listUrl [listUrl]`",
-        "Example": ""
-      },
-      {
-        "Description": "",
-        "Example": ": Server- or web-relative URL of the list where the field is located. Specify only one of listTitle, listId or listUrl"
-      },
-      {
-        "Description": ": The ID of the field to retrieve. Specify id or title but not both",
-        "Example": "`-i, --id [id]`"
-      },
-      {
-        "Description": "`-t, --title [title]`",
-        "Example": ""
-      },
-      {
-        "Description": "m365 spo field get [options]",
-        "Example": ": The display name (case-sensitive) of the field to remove. Specify id or title, or group but not both"
-      },
-      {
-        "Description": "import Global from '/docs/cmd/_global.mdx';",
-        "Example": "Retrieves information about the specified list- or site column"
-      },
-      {
-        "Description": null,
-        "Example": "m365 spo field get --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listUrl \"Lists/Events\" --title \"Title\""
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo list list",
-    "Description": "Gets all lists within the specified site",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the lists to retrieve are located.`-p, --properties [properties]`: Comma-separated list of properties to retrieve. Will retrieve all properties if not specified.`--filter [filter]`: OData filter to use to query the lists with.",
-    "Examples": [
-      {
-        "Description": "m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Return all lists located in in a specific site."
-      },
-      {
-        "Description": "m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x --properties \"BaseTemplate,ParentWebUrl\"",
-        "Example": "Return all lists located in in a specific site with specific properties."
-      },
-      {
-        "Description": "m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x --properties \"Id,Title,RootFolder/ServerRelativeUrl\"",
-        "Example": "Return all lists located in in a specific site with the Id, Title and ServerRelativeUrl properties."
-      },
-      {
-        "Description": "m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x --filter \"BaseTemplate eq 100\"",
-        "Example": "Return all lists located in in a specific site based on the given filter."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo applicationcustomizer list",
-    "Description": "Get a list of application customizers that are added to a site.",
-    "Options": "`-u, --webUrl <webUrl>`: The url of the site.`-s, --scope [scope]`: Scope of the application customizers. Allowed values `Site`, `Web`, `All`. Defaults to `All`",
-    "Examples": [
-      {
-        "Description": "m365 spo applicationcustomizer list --webUrl https://contoso.sharepoint.com/sites/sales",
-        "Example": "Retrieves a list of application customizers."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo term group list",
-    "Description": "Lists taxonomy term groups",
-    "Options": "`-u, --webUrl [webUrl]`: If specified, allows you to list term groups from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.",
-    "Examples": [
-      {
-        "Description": "m365 spo term group list",
-        "Example": "List taxonomy term groups."
-      },
-      {
-        "Description": "m365 spo term group list --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "List taxonomy term groups from the specified sitecollection."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo site apppermission get",
-    "Description": "Get a specific application permissions for the site",
-    "Options": "`-u, --siteUrl <siteUrl>`: URL of the site collection where the permission to retrieve is located`-i, --id <id>`: ID of the permission to retrieve",
-    "Examples": [
-      {
-        "Description": "m365 spo site apppermission get --siteUrl https://contoso.sharepoint.com/sites/project-x --id aTowaS50fG1zLnNwLmV4dHw4OWVhNWM5NC03NzM2LTRlMjUtOTVhZC0zZmE5NWY2MmI2NmVAZGUzNDhiYzctMWFlYi00NDA2LThjYjMtOTdkYjAyMWNhZGI0",
-        "Example": "Return a specific application permissions for the https://contoso.sharepoint.com/sites/project-x site collection with permission id aTowaS50fG1zLnNwLmV4dHw4OWVhNWM5NC03NzM2LTRlMjUtOTVhZC0zZmE5NWY2MmI2NmVAZGUzNDhiYzctMWFlYi00NDA2LThjYjMtOTdkYjAyMWNhZGI0"
-      }
-    ]
-  },
-  {
     "Command": "m365 spo web clientsidewebpart list",
     "Description": "Lists available client-side web parts",
     "Options": "`-u, --webUrl <webUrl>`: URL of the site for which to retrieve the information",
@@ -788,164 +2344,13 @@ export const Commands = [
     ]
   },
   {
-    "Command": "m365 spo user list",
-    "Description": "Lists all the users within specific web",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the web to list the users from",
+    "Command": "m365 teams message get",
+    "Description": "Retrieves a message from a channel in a Microsoft Teams team",
+    "Options": "`-t, --teamId <teamId>`: The ID of the team where the channel is located.`-c, --channelId <channelId>`: The ID of the channel that contains the message.`-i, --id <id>`: The ID of the message to retrieve.",
     "Examples": [
       {
-        "Description": "m365 spo user list --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Get list of users in a web"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo group list",
-    "Description": "Lists all the groups within specific web",
-    "Options": "`-u, --webUrl <webUrl>`: Url of the web to list the group within`--associatedGroupsOnly`: Get only the associated visitor, member and owner groups of the site.",
-    "Examples": [
-      {
-        "Description": "`-u, --webUrl <webUrl>`: Url of the web to list the group within",
-        "Example": "Lists all the groups within a specific web"
-      },
-      {
-        "Description": ": Get only the associated visitor, member and owner groups of the site.",
-        "Example": "`--associatedGroupsOnly`"
-      },
-      {
-        "Description": ": Url of the web to list the group within",
-        "Example": "`-u, --webUrl <webUrl>`"
-      },
-      {
-        "Description": "`--associatedGroupsOnly`",
-        "Example": ""
-      },
-      {
-        "Description": "m365 spo group list [options]",
-        "Example": ": Get only the associated visitor, member and owner groups of the site."
-      },
-      {
-        "Description": "import Global from '/docs/cmd/_global.mdx';",
-        "Example": "Lists all the groups within specific web"
-      },
-      {
-        "Description": null,
-        "Example": "m365 spo group list --webUrl \"https://contoso.sharepoint.com/sites/contoso\" --associatedGroupsOnly"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo orgassetslibrary list",
-    "Description": "List all libraries that are assigned as asset library",
-    "Options": null,
-    "Examples": [
-      {
-        "Description": "m365 spo orgassetslibrary list",
-        "Example": "List all libraries that are assigned as asset library"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo sitedesign task list",
-    "Description": "Lists site designs scheduled for execution on the specified site",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site for which to list site designs scheduled for execution",
-    "Examples": [
-      {
-        "Description": "m365 spo sitedesign task list --webUrl https://contoso.sharepoint.com/sites/team-a",
-        "Example": "List site designs scheduled for execution on the specified site"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo file sharinglink get",
-    "Description": "Gets details about a specific sharing link of a file",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located.`--fileUrl [fileUrl]`: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both.`--fileId [fileId]`: The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.`-i, --id <id>`: The ID of the sharing link.",
-    "Examples": [
-      {
-        "Description": "m365 spo file sharinglink get --webUrl 'https://contoso.sharepoint.com/sites/demo' --fileId daebb04b-a773-4baa-b1d1-3625418e3234 --id 1ba739c5-e693-4c16-9dfa-042e4ec62972",
-        "Example": "Gets a specific sharing link of a file by id."
-      },
-      {
-        "Description": "m365 spo file sharinglink get --webUrl 'https://contoso.sharepoint.com/sites/demo' --fileUrl 'Shared Documents/document.docx' --id 1ba739c5-e693-4c16-9dfa-042e4ec62972",
-        "Example": "Gets a specific sharing link of a file by a specified site-relative URL."
-      },
-      {
-        "Description": "m365 spo file sharinglink get --webUrl 'https://contoso.sharepoint.com/sites/demo' --fileUrl '/sites/demo/Shared Documents/document.docx' --id 1ba739c5-e693-4c16-9dfa-042e4ec62972",
-        "Example": "Gets a specific sharing link of a file by a specified server-relative URL."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo contenttypehub get",
-    "Description": "Returns the URL of the SharePoint Content Type Hub of the Tenant",
-    "Options": null,
-    "Examples": [
-      {
-        "Description": "m365 spo contenttypehub get [options]",
-        "Example": "Retrieve the Content Type Hub URL"
-      },
-      {
-        "Description": "import Global from '/docs/cmd/_global.mdx';",
-        "Example": "Returns the URL of the SharePoint Content Type Hub of the Tenant"
-      },
-      {
-        "Description": null,
-        "Example": "m365 spo contenttypehub get"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo serviceprincipal permissionrequest list",
-    "Description": "Lists pending permission requests",
-    "Options": "m365 spo sp permissionrequest list",
-    "Examples": [
-      {
-        "Description": null,
-        "Example": "The admin role that's required to list permissions depends on the API. To approve permissions to any of the third-party APIs registered in the tenant, the application administrator role is sufficient. To approve permissions for Microsoft Graph or any other Microsoft API, the Global Administrator role is required."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo applicationcustomizer get",
-    "Description": "Get an application customizer that is added to a site.",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site.`-t, --title [title]`: The title of the Application Customizer. Specify either `title`, `id`, or `clientSideComponentId`.`-i, --id [id]`: The id of the Application Customizer. Specify either `title`, `id`, or `clientSideComponentId`.`-c, --clientSideComponentId  [clientSideComponentId]`: The Client Side Component Id (GUID) of the application customizer. Specify either `title`, `id`, or `clientSideComponentId`.`-s, --scope [scope]`: Scope of the application customizer. Allowed values: `Site`, `Web`, `All`. Defaults to `All`.",
-    "Examples": [
-      {
-        "Description": "m365 spo applicationcustomizer get --title \"Some customizer\" --webUrl https://contoso.sharepoint.com/sites/sales",
-        "Example": "Retrieves an application customizer by title."
-      },
-      {
-        "Description": "m365 spo applicationcustomizer get --id 14125658-a9bc-4ddf-9c75-1b5767c9a337 --webUrl https://contoso.sharepoint.com/sites/sales",
-        "Example": "Retrieves an application customizer by id."
-      },
-      {
-        "Description": "m365 spo applicationcustomizer get --clientSideComponentId 7096cded-b83d-4eab-96f0-df477ed7c0bc --webUrl https://contoso.sharepoint.com/sites/sales",
-        "Example": "Retrieves an application customizer by clientSideComponentId."
-      },
-      {
-        "Description": "m365 spo applicationcustomizer get --title \"Some customizer\" --webUrl https://contoso.sharepoint.com/sites/sales --scope site",
-        "Example": "Retrieves an application customizer by title available at the site scope."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo navigation node get",
-    "Description": "Gets information about a specific navigation node.",
-    "Options": "`-u, --webUrl <webUrl>`: Absolute URL of the site.`--id <id>`: Id of the navigation node.",
-    "Examples": [
-      {
-        "Description": "m365 spo navigation node get --webUrl https://contoso.sharepoint.com/sites/team-a --id 2209",
-        "Example": "Retrieve information for a specific navigation node."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo hidedefaultthemes get",
-    "Description": "Gets the current value of the HideDefaultThemes setting",
-    "Options": null,
-    "Examples": [
-      {
-        "Description": "m365 spo hidedefaultthemes get",
-        "Example": "Get the current value of the HideDefaultThemes setting"
+        "Description": "m365 teams message get --teamId 5f5d7b71-1161-44d8-bcc1-3da710eb4171 --channelId 19:88f7e66a8dfe42be92db19505ae912a8@thread.skype --id 1540747442203",
+        "Example": "Retrieve the specified message from a channel of the Microsoft Teams team."
       }
     ]
   },
@@ -957,743 +2362,6 @@ export const Commands = [
       {
         "Description": null,
         "Example": "To use this command you must be a Global administrator."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo file sharinglink list",
-    "Description": "Lists all the sharing links of a specific file",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located.`--fileUrl [fileUrl]`: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both.`--fileId [fileId]`: The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.`-s, --scope [scope]`: Filter the results to only sharing links of a given scope: `anonymous`, `users` or `organization`. By default all sharing links are listed.",
-    "Examples": [
-      {
-        "Description": "m365 spo file sharinglink list --webUrl https://contoso.sharepoint.com/sites/demo --fileId daebb04b-a773-4baa-b1d1-3625418e3234",
-        "Example": "List sharing links of a file by id"
-      },
-      {
-        "Description": "m365 spo file sharinglink list --webUrl https://contoso.sharepoint.com/sites/demo --fileUrl \"/sites/demo/shared documents/document.docx\"",
-        "Example": "List sharing links of a file by url"
-      },
-      {
-        "Description": "m365 spo file sharinglink list --webUrl https://contoso.sharepoint.com/sites/demo --fileUrl \"/sites/demo/shared documents/document.docx\" --scope anonymous",
-        "Example": "List anonymous sharing links of a file by url"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo hubsite data get",
-    "Description": "Get hub site data for the specified site",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site for which to retrieve hub site data.`--forceRefresh`: Set, to refresh the server cache with the latest updates.",
-    "Examples": [
-      {
-        "Description": "m365 spo hubsite data get --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Get information about the hub site data for a specific site with URL."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo listitem attachment get",
-    "Description": "Gets an attachment from a list item",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list item is located.`--listId [listId]`: ID of the list. Specify either `listTitle`, `listId` or `listUrl`.`--listTitle [listTitle]`: Title of the list. Specify either `listTitle`, `listId` or `listUrl`.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`.`--listItemId <listItemId>`: The ID of the list item.`-n, --fileName <fileName>`: Name of the file to get.",
-    "Examples": [
-      {
-        "Description": "m365 spo listitem attachment get --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle \"Demo List\" --listItemId 147 --fileName \"File1.jpg\"",
-        "Example": "Get an attachment from a list item by using list title."
-      },
-      {
-        "Description": "m365 spo listitem attachment get --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl \"/sites/project-x/Lists/DemoList\" --listItemId 147 --fileName \"File1.jpg\"",
-        "Example": "Get an attachment from a list item by using list URL."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo hubsite list",
-    "Description": "Lists hub sites in the current tenant",
-    "Options": "`-i, --includeAssociatedSites`: Include the associated sites in the result (only in JSON output).",
-    "Examples": [
-      {
-        "Description": "m365 spo hubsite list",
-        "Example": "List hub sites in the current tenant"
-      },
-      {
-        "Description": "m365 spo hubsite list --includeAssociatedSites --output json",
-        "Example": "List hub sites, including their associated sites, in the current tenant. Associated site info is only shown in JSON output."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo page column get",
-    "Description": "Get information about a specific column of a modern page",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.`-n, --pageName <pageName>`: Name of the page to get column information of.`-s, --section <section>`: ID of the section where the column is located.`-c, --column <column>`: ID of the column for which to retrieve more information.",
-    "Examples": [
-      {
-        "Description": "m365 spo page column get --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx --section 1 --column 1",
-        "Example": "Get information about the first column in the first section of a modern page"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo userprofile get",
-    "Description": "Get SharePoint user profile properties for the specified user",
-    "Options": "`-u, --userName <userName>`: Account name of the user",
-    "Examples": [
-      {
-        "Description": "m365 spo userprofile get --userName 'john.doe@mytenant.onmicrosoft.com'",
-        "Example": "Get SharePoint user profile for the specified user"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo page list",
-    "Description": "Lists all modern pages in the given site",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site from which to retrieve available pages.",
-    "Examples": [
-      {
-        "Description": "m365 spo page list --webUrl https://contoso.sharepoint.com/sites/team-a",
-        "Example": "List all modern pages in the specific site"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo tenant appcatalogurl get",
-    "Description": "Gets the URL of the tenant app catalog",
-    "Options": null,
-    "Examples": [
-      {
-        "Description": "m365 spo tenant appcatalogurl get",
-        "Example": "Get the URL of the tenant app catalog"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo sitedesign get",
-    "Description": "Gets information about the specified site design",
-    "Options": "`-i, --id [id]`: Site design ID. Specify either `id` or `title` but not both.`--title [title]`: Site design title. Specify either `id` or `title` but not both.",
-    "Examples": [
-      {
-        "Description": "m365 spo sitedesign get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a",
-        "Example": "Get information about the site design with ID 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a"
-      },
-      {
-        "Description": "m365 spo sitedesign get --title \"Contoso Site Design\"",
-        "Example": "Get information about the site design with title Contoso Site Design"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo eventreceiver list",
-    "Description": "Retrieves event receivers for the specified web, site or list.",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the web for which to retrieve the event receivers.`--listTitle [listTitle]`: The title of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.`--listId [listId]`: The id of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.`--listUrl [listUrl]`: The url of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.`-s, --scope [scope]`: The scope of which to retrieve the Event Receivers. Can be either \"site\" or \"web\". Defaults to \"web\". Only applicable when not specifying any of the list properties.",
-    "Examples": [
-      {
-        "Description": "`-u, --webUrl <webUrl>`",
-        "Example": "Retrieves event receivers in web https://contoso.sharepoint.com/sites/contoso-sales."
-      },
-      {
-        "Description": "`--listTitle [listTitle]`",
-        "Example": ": The URL of the web for which to retrieve the event receivers."
-      },
-      {
-        "Description": "`--listId [listId]`",
-        "Example": ": The title of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`."
-      },
-      {
-        "Description": "`--listUrl [listUrl]`",
-        "Example": ": The id of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`."
-      },
-      {
-        "Description": "`-s, --scope [scope]`",
-        "Example": ": The url of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`."
-      },
-      {
-        "Description": "`-u, --webUrl <webUrl>`",
-        "Example": ": The scope of which to retrieve the Event Receivers. Can be either \"site\" or \"web\". Defaults to \"web\". Only applicable when not specifying any of the list properties."
-      },
-      {
-        "Description": "",
-        "Example": ": The URL of the web for which to retrieve the event receivers."
-      },
-      {
-        "Description": ": The title of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.",
-        "Example": "`--listTitle [listTitle]`"
-      },
-      {
-        "Description": "`--listId [listId]`",
-        "Example": ""
-      },
-      {
-        "Description": "",
-        "Example": ": The id of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`."
-      },
-      {
-        "Description": ": The url of the list for which to retrieve the event receivers, _if the event receivers should be retrieved from a list_. Specify either `listTitle`, `listId` or `listUrl`.",
-        "Example": "`--listUrl [listUrl]`"
-      },
-      {
-        "Description": "`-s, --scope [scope]`",
-        "Example": ""
-      },
-      {
-        "Description": "m365 spo eventreceiver list [options]",
-        "Example": ": The scope of which to retrieve the Event Receivers. Can be either \"site\" or \"web\". Defaults to \"web\". Only applicable when not specifying any of the list properties."
-      },
-      {
-        "Description": "import Global from '/docs/cmd/_global.mdx';",
-        "Example": "Retrieves event receivers for the specified web, site or list."
-      },
-      {
-        "Description": null,
-        "Example": "m365 spo eventreceiver list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listUrl '/sites/contoso-sales/lists/Events'"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo listitem list",
-    "Description": "Gets a list of items from the specified list",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site from which the item should be retrieved.`-l, --listId [listId]`: ID of the list. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.`-t, --listTitle [listTitle]`: Title of the list. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.`-q, --camlQuery [camlQuery]`: CAML query to use to query the list of items with.`--fields [fields]`: Comma-separated list of fields to retrieve. Will retrieve all fields if not specified and json output is requested. Specify `camlQuery` or `fields` but not both.`-l, --filter [filter]`: OData filter to use to query the list of items with. Specify `camlQuery` or `filter` but not both.`-s, --pageSize [pageSize]`: Number of list items to return. Specify `camlQuery` or `pageSize` but not both. The default value is 5000.`-n, --pageNumber [pageNumber]`: Page number to return if `pageSize` is specified (first page is indexed as value of 0).",
-    "Examples": [
-      {
-        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Get all items from a list named Demo List"
-      },
-      {
-        "Description": "m365 spo listitem list --listId 935c13a0-cc53-4103-8b48-c1d0828eaa7f --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Get all items from a list with ID 935c13a0-cc53-4103-8b48-c1d0828eaa7f"
-      },
-      {
-        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --fields \"ID,Title,Modified\"",
-        "Example": "Get all items from list named Demo List. For each item, retrieve the value of the ID, Title and Modified fields"
-      },
-      {
-        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --fields \"ID,Title,Modified,Company/Title\"",
-        "Example": "Get all items from list named Demo List. For each item, retrieve the value of the ID, Title, Modified fields, and the value of lookup field Company"
-      },
-      {
-        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --filter \"Title eq 'Demo list item'\"",
-        "Example": "From a list named Demo List get all items with title Demo list item using an OData filter"
-      },
-      {
-        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --pageSize 100 --pageNumber 0",
-        "Example": "From a list named Demo List get the first 100 items"
-      },
-      {
-        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --pageSize 10 --pageNumber 1",
-        "Example": "From a list named Demo List get the second batch of 10 items"
-      },
-      {
-        "Description": "m365 spo listitem list --listUrl /sites/project-x/documents --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Get all items from a list by server-relative URL"
-      },
-      {
-        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --camlQuery \"<View><Query><Where><Eq><FieldRef Name='Title' /><Value Type='Text'>Demo list item</Value></Eq></Where></Query><RowLimit Paged='TRUE'>5000</RowLimit></View>\"",
-        "Example": "From a list named Demo List get all items with title Demo list item using a CAML query"
-      },
-      {
-        "Description": "m365 spo listitem list --listTitle \"Demo List\" --webUrl https://contoso.sharepoint.com/sites/project-x --camlQuery \"<View Scope='RecursiveAll'><Query></Query><ViewFields><FieldRef Name='Title'/></ViewFields><RowLimit Paged='TRUE'>5000</RowLimit></View>\"",
-        "Example": "From a library named Demo Library with 5000+ files and folders, get all items recursively without running into a list view threshold exception, using a CAML query"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo propertybag list",
-    "Description": "Gets property bag values",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site from which the property bag value should be retrieved.`--folder [folder]`: Site-relative URL of the folder from which to retrieve property bag value. Case-sensitive.",
-    "Examples": [
-      {
-        "Description": "m365 spo propertybag list --webUrl https://contoso.sharepoint.com/sites/test",
-        "Example": "Return property bag values located in the given site"
-      },
-      {
-        "Description": "m365 spo propertybag list --webUrl https://contoso.sharepoint.com/sites/test --folder /",
-        "Example": "Return property bag values located in the given site root folder"
-      },
-      {
-        "Description": "m365 spo propertybag list --webUrl https://contoso.sharepoint.com/sites/test --folder '/Shared Documents'",
-        "Example": "Return property bag values located in the given site document library"
-      },
-      {
-        "Description": "m365 spo propertybag list --webUrl https://contoso.sharepoint.com/sites/test --folder '/Shared Documents/MyFolder'",
-        "Example": "Return property bag values located in folder in the given site document library"
-      },
-      {
-        "Description": "m365 spo propertybag list --webUrl https://contoso.sharepoint.com/sites/test --folder /Lists/MyList",
-        "Example": "Return property bag values located in the given site list"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo list view get",
-    "Description": "Gets information about specific list view",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list is located`--listId [listId]`: ID of the list where the view is located. Specify only one of `listTitle`, `listId` or `listUrl``--listTitle [listTitle]`: Title of the list where the view is located. Specify only one of `listTitle`, `listId` or `listUrl``--listUrl [listUrl]`: Server- or web-relative URL of the list where the view is located. Specify only one of `listTitle`, `listId` or `listUrl``--id [id]`: ID of the view to get. Specify `title` or `id` but not both`--title [title]`: Title of the view to get. Specify `title` or `id` but not both",
-    "Examples": [
-      {
-        "Description": "m365 spo list view get --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'My List' --title 'All Items'",
-        "Example": "Gets a list view by name from a list located in site https://contoso.sharepoint.com/sites/project-x"
-      },
-      {
-        "Description": "m365 spo list view get --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Lists/My List' --id 330f29c5-5c4c-465f-9f4b-7903020ae1ce",
-        "Example": "Gets a list view by ID from a list located in site https://contoso.sharepoint.com/sites/project-x"
-      },
-      {
-        "Description": "m365 spo list view get --webUrl https://contoso.sharepoint.com/sites/project-x --listId 330f29c5-5c4c-465f-9f4b-7903020ae1c1 --title 'All Items'",
-        "Example": "Gets a list view by name from a list located in site https://contoso.sharepoint.com/sites/project-x. Retrieve the list by its ID"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo list view list",
-    "Description": "Lists views configured on the specified list",
-    "Options": " `-u, --webUrl <webUrl>`: URL of the site where the list is located `-i, --listId [listId]`: ID of the list for which to list configured views. Specify either `listId`, `listTitle`, or `listUrl`. `-t, --listTitle [listTitle]`: Title of the list for which to list configured views. Specify either `listId`, `listTitle`, or `listUrl`. `--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listId` , `listTitle` or `listUrl`.",
-    "Examples": [
-      {
-        "Description": "m365 spo list view list --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle Documents",
-        "Example": "List all views for a list by title"
-      },
-      {
-        "Description": "m365 spo list view list --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf",
-        "Example": "List all views for a list by ID"
-      },
-      {
-        "Description": "m365 spo list view list --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl '/sites/project-x/lists/Events'",
-        "Example": "List all views for a list by URL"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo page section list",
-    "Description": "List sections in the specific modern page",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.`-n, --pageName <pageName>`: Name of the page to list sections of.",
-    "Examples": [
-      {
-        "Description": "m365 spo page section list --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx",
-        "Example": "List sections of a modern page"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo propertybag get",
-    "Description": "Gets the value of the specified property from the property bag",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site from which the property bag value should be retrieved.`-k, --key <key>`: Key of the property for which the value should be retrieved. Case-sensitive.`--folder [folder]`: Site-relative URL of the folder from which to retrieve property bag value. Case-sensitive.",
-    "Examples": [
-      {
-        "Description": "m365 spo propertybag get --webUrl https://contoso.sharepoint.com/sites/test --key key1",
-        "Example": "Returns the value of the property from the property bag located in the given site"
-      },
-      {
-        "Description": "m365 spo propertybag get --webUrl https://contoso.sharepoint.com/sites/test --key key1 --folder /",
-        "Example": "Returns the value of the property from the property bag located in root folder of the given site"
-      },
-      {
-        "Description": "m365 spo propertybag get --webUrl https://contoso.sharepoint.com/sites/test --key key1 --folder '/Shared Documents'",
-        "Example": "Returns the value of the property from the property bag located in document library of the given site"
-      },
-      {
-        "Description": "m365 spo propertybag get --webUrl https://contoso.sharepoint.com/sites/test --key key1 --folder '/Shared Documents/MyFolder'",
-        "Example": "Returns the value of the property from the property bag located in folder in a document library located in the given site"
-      },
-      {
-        "Description": "m365 spo propertybag get --webUrl https://contoso.sharepoint.com/sites/test --key key1 --folder /Lists/MyList",
-        "Example": "Returns the value of the property from the property bag located in a list in the given site"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo knowledgehub get",
-    "Description": "Gets the Knowledge Hub Site URL for your tenant",
-    "Options": null,
-    "Examples": [
-      {
-        "Description": "m365 spo knowledgehub get",
-        "Example": "Gets the Knowledge Hub Site URL for your tenant."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo list contenttype list",
-    "Description": "Lists content types configured on the list",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list is located.`-l, --listId [listId]`: ID of the list. Specify either `listTitle`, `listId`, or `listUrl`.`-t, --listTitle [listTitle]`: Title of the list. Specify either `listTitle`, `listId`, or `listUrl`.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listTitle`, `listId`, or `listUrl`.",
-    "Examples": [
-      {
-        "Description": "m365 spo list contenttype list --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf",
-        "Example": "List all content types configured on a specific list retrieved by id in a specific site."
-      },
-      {
-        "Description": "m365 spo list contenttype list --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle Documents",
-        "Example": "List all content types configured on a specific list retrieved by title in a specific site."
-      },
-      {
-        "Description": "m365 spo list contenttype list --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'sites/project-x/Documents'",
-        "Example": "List all content types configured on a specific list retrieved by server relative URL in a specific site."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo term get",
-    "Description": "Gets information about the specified taxonomy term",
-    "Options": "`-u, --webUrl [webUrl]`: If specified, allows you to get a term from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.`-i, --id [id]`: ID of the term to retrieve. Specify `name` or `id` but not both.`-n, --name [name]`: Name of the term to retrieve. Specify `name` or `id` but not both.`--termGroupId [termGroupId]`: ID of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both.`--termGroupName [termGroupName]`: Name of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both.`--termSetId [termSetId]`: ID of the term set to which the term belongs. Specify `termSetId` or `termSetName` but not both.`--termSetName [termSetName]`: Name of the term set to which the term belongs. Specify `termSetId` or `termSetName` but not both.",
-    "Examples": [
-      {
-        "Description": "m365 spo term get --webUrl https://contoso.sharepoint.com/sites/project-x --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb",
-        "Example": "Get information about a taxonomy term using its ID from the specified sitecollection."
-      },
-      {
-        "Description": "m365 spo term get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb",
-        "Example": "Get information about a taxonomy term using its ID."
-      },
-      {
-        "Description": "m365 spo term get --name IT --termGroupName People --termSetName Department",
-        "Example": "Get information about a taxonomy term using its name, retrieving the parent term group and term set using their names."
-      },
-      {
-        "Description": "m365 spo term get --name IT --termGroupId 5c928151-c140-4d48-aab9-54da901c7fef --termSetId 8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f",
-        "Example": "Get information about a taxonomy term using its name, retrieving the parent term group and term set using their IDs."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo list get",
-    "Description": "Gets information about the specific list",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list to retrieve is located.`-i, --id [id]`: ID of the list to retrieve information for. Specify either `id`, `title`, or `url` but not multiple.`-t, --title [title]`: Title of the list to retrieve information for. Specify either `id`, `title`, or `url` but not multiple.`--url [url]`: Server- or site-relative URL of the list. Specify either `id`, `title`, or `url` but not multiple.`-p, --properties [properties]`: Comma-separated list of properties to retrieve from the list. Will retrieve all properties possible from default response, if not specified.`--withPermissions`: Set if you want to return associated roles and permissions of the list.",
-    "Examples": [
-      {
-        "Description": "m365 spo list get --id 0cd891ef-afce-4e55-b836-fce03286cccf --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Get information about a list with specified ID located in the specified site."
-      },
-      {
-        "Description": "m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Get information about a list with specified title located in the specified site."
-      },
-      {
-        "Description": "m365 spo list get --url 'sites/project-x/Documents' --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Get information about a list with specified server relative url located in the specified site."
-      },
-      {
-        "Description": "m365 spo list get --url 'Shared Documents' --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Get information about a list with specified site-relative URL located in the specified site."
-      },
-      {
-        "Description": "m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --properties \"Title,Id,HasUniqueRoleAssignments,AllowContentTypes\"",
-        "Example": "Get information about a list returning the specified list properties."
-      },
-      {
-        "Description": "m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --properties \"Title,Id,RootFolder/ServerRelativeUrl\"",
-        "Example": "Get information about a list returning the list Id, Title and ServerRelativeUrl properties."
-      },
-      {
-        "Description": "m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --withPermissions",
-        "Example": "Get information about a list along with the roles and permissions."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo web retentionlabel list",
-    "Description": "Get a list of retention labels that are available on a site.",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site.",
-    "Examples": [
-      {
-        "Description": "m365 spo web retentionlabel list --webUrl 'https://contoso.sharepoint.com/sites/sales'",
-        "Example": "Get a list of retention labels for the Sales site"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo commandset get",
-    "Description": "Get a ListView Command Set that is added to a site.",
-    "Options": "`-u, --webUrl <webUrl>`: Url of the site.`-t, --title [title]`: The title of the ListView Command Set. Specify either `title`, `id` or `clientSideComponentId`.`-i, --id [id]`: The id of the ListView Command Set. Specify either `title`, `id` or `clientSideComponentId`.`-c, --clientSideComponentId [clientSideComponentId]`: The id of the ListView Command Set. Specify either `title`, `id` or `clientSideComponentId`.`-s, --scope [scope]`: Scope of the ListView Command Set. Allowed values: `Site`, `Web`, `All`. Defaults to `All`.",
-    "Examples": [
-      {
-        "Description": "m365 spo commandset get --title \"Some customizer\" --webUrl https://contoso.sharepoint.com/sites/sales",
-        "Example": "Retrieves a ListView Command Set by title."
-      },
-      {
-        "Description": "m365 spo commandset get --id 14125658-a9bc-4ddf-9c75-1b5767c9a337 --webUrl https://contoso.sharepoint.com/sites/sales -scope Web",
-        "Example": "Retrieves a ListView Command Set by id with scope 'Web'."
-      },
-      {
-        "Description": "m365 spo commandset get --clientSideComponentId c1cbd896-5140-428d-8b0c-4873be19f5ac --webUrl https://contoso.sharepoint.com/sites/sales --scope Site",
-        "Example": "Retrieves a ListView Command Set by clientSideComponentId with scope 'Site'."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo term set list",
-    "Description": "Lists taxonomy term sets from the given term group",
-    "Options": "`-u, --webUrl [webUrl]`: If specified, allows you to list term sets from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.`--termGroupId [termGroupId]`: ID of the term group from which to retrieve term sets. Specify `termGroupName` or `termGroupId` but not both.`--termGroupName [termGroupName]`: Name of the term group from which to retrieve term sets. Specify `termGroupName` or `termGroupId` but not both.",
-    "Examples": [
-      {
-        "Description": "m365 spo term set list --termGroupName PnPTermSets",
-        "Example": "List taxonomy term sets from the term group with the given name."
-      },
-      {
-        "Description": "m365 spo term set list --termGroupId 0e8f395e-ff58-4d45-9ff7-e331ab728beb",
-        "Example": "List taxonomy term sets from the term group with the given ID."
-      },
-      {
-        "Description": "m365 spo term set list --termGroupName PnPTermSets --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "List taxonomy term sets from the specified sitecollection, from the term group with the given name."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo commandset list",
-    "Description": "Get a list of ListView Command Sets that are added to a site.",
-    "Options": "`-u, --webUrl <webUrl>`: The url of the site.`-s, --scope [scope]`: Scope of the ListView Command Sets. Allowed values `Site`, `Web`, `All`. Default to `All`",
-    "Examples": [
-      {
-        "Description": "m365 spo commandset list --webUrl https://contoso.sharepoint.com/sites/sales",
-        "Example": "Retrieves a list of ListView Command Sets."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo page control list",
-    "Description": "Lists controls on the specific modern page",
-    "Options": "`-n, --pageName <pageName>`: Name of the page to list controls of.`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.",
-    "Examples": [
-      {
-        "Description": "m365 spo page control list --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx",
-        "Example": "List controls on the modern page"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo listitem attachment list",
-    "Description": "Gets the attachments associated to a list item",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site from which the item should be retrieved`--listId [listId]`: ID of the list where the item should be retrieved. Specify either `listTitle`, `listId` or `listUrl``--listTitle [listTitle]`: Title of the list where the item should be retrieved. Specify either `listTitle`, `listId` or `listUrl``--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl``--listItemId <listItemId>`: ID of the list item",
-    "Examples": [
-      {
-        "Description": "m365 spo listitem attachment list --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle \"Demo List\" --listItemId 147",
-        "Example": "Gets the attachments from list item with listItemId 147 in list with title Demo List in site https://contoso.sharepoint.com/sites/project-x"
-      },
-      {
-        "Description": "m365 spo listitem attachment list --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf --listItemId 147",
-        "Example": "Gets the attachments from list item with listItemId 147 in list with id 0cd891ef-afce-4e55-b836-fce03286cccf in site https://contoso.sharepoint.com/sites/project-x"
-      },
-      {
-        "Description": "m365 spo listitem attachment list --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl /sites/project-x/Documents --listItemId 147",
-        "Example": "Gets the attachments from a specific list item in a specific list obtained by server-relative URL in a specific site"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo file get",
-    "Description": "Gets information about the specified file",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located`--url [url]`: The server- or site-relative decoded URL of the file to retrieve. Specify either `url` or `id` but not both`-i, --id [id]`: The UniqueId (GUID) of the file to retrieve. Specify either `url` or `id` but not both`--asString`: Set to retrieve the contents of the specified file as string`--asListItem`: Set to retrieve the underlying list item`--asFile`: Set to save the file to the path specified in the path option`-p, --path [path]`: The local path where to save the retrieved file. Must be specified when the `--asFile` option is used`--withPermissions`: Set if you want to return associated roles and permissions",
-    "Examples": [
-      {
-        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6'",
-        "Example": "Get file properties for a file with id (UniqueId) parameter located in a site"
-      },
-      {
-        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --asString",
-        "Example": "Get contents of the file with id (UniqueId) parameter located in a site"
-      },
-      {
-        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --asListItem",
-        "Example": "Get list item properties for a file with id (UniqueId) parameter located in a site"
-      },
-      {
-        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --asFile --path /Users/user/documents/SavedAsTest1.docx",
-        "Example": "Saves the file with id (UniqueId) parameter located in a site to a local file"
-      },
-      {
-        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --url '/sites/project-x/documents/Test1.docx'",
-        "Example": "Return file properties for a file with server-relative url located in a site"
-      },
-      {
-        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --url '/sites/project-x/documents/Test1.docx' --asString",
-        "Example": "Returns a file as string for a file with server-relative url located in a site"
-      },
-      {
-        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --url '/sites/project-x/documents/Test1.docx' --asListItem",
-        "Example": "Returna the list item properties for a file with the server-relative url located in a site"
-      },
-      {
-        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --url '/sites/project-x/documents/Test1.docx' --asFile --path /Users/user/documents/SavedAsTest1.docx",
-        "Example": "Saves a file with the server-relative url located in a site to a local file"
-      },
-      {
-        "Description": "m365 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --withPermissions",
-        "Example": "Gets the file properties for a file with id (UniqueId) parameter located in a site with permissions"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo list retentionlabel get",
-    "Description": "Gets the default retention label set on the specified list or library.",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list to get the label from is located.`-l, --listId [listId]`: ID of the list to get the label from. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.`-t, --listTitle [listTitle]`: Title of the list to get the label from. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.",
-    "Examples": [
-      {
-        "Description": "m365 spo list retentionlabel get --listTitle ContosoList --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Gets retention label set on the list with specified title located in the specified site."
-      },
-      {
-        "Description": "m365 spo list retentionlabel get --listId cc27a922-8224-4296-90a5-ebbc54da2e85 --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Gets retention label set on the list with specified id located in the specified site."
-      },
-      {
-        "Description": "m365 spo list retentionlabel get --listUrl 'sites/project-x/Documents' --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Gets retention label set on the list with specified server relative url located in the specified site."
-      },
-      {
-        "Description": "m365 spo list retentionlabel get --listUrl 'Shared Documents' --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Gets retention label set on the list with specified site-relative URL located in the specified site."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo folder list",
-    "Description": "Returns all folders under the specified parent folder",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the folders to list are located.`-p, --parentFolderUrl <parentFolderUrl>`: The server- or site-relative decoded URL of the parent folder.`--fields [fields]`: Comma-separated list of fields to retrieve. Will retrieve all fields if not specified and json output is requested.`--filter [filter]`: OData filter to use to query the list of folders with.`-r, --recursive`: Set to retrieve nested folders.",
-    "Examples": [
-      {
-        "Description": "m365 spo folder list --webUrl https://contoso.sharepoint.com/sites/project-x --parentFolderUrl '/Shared Documents'",
-        "Example": "Gets list of folders under a parent folder with site-relative URL"
-      },
-      {
-        "Description": "m365 spo folder list --webUrl https://contoso.sharepoint.com/sites/project-x --parentFolderUrl '/sites/project-x/Shared Documents' --recursive",
-        "Example": "Gets recursive list of folders under a specific folder on a specific site"
-      },
-      {
-        "Description": "m365 spo folder list --webUrl https://contoso.sharepoint.com/sites/project-x --parentFolderUrl '/Shared Documents' --fields ListItemAllFields/Id --filter \"startswith(Name,'Folder')\"",
-        "Example": "Return a filtered list of folders and only return the list item ID"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo tenant recyclebinitem list",
-    "Description": "Returns all modern and classic site collections in the tenant scoped recycle bin",
-    "Options": null,
-    "Examples": [
-      {
-        "Description": "m365 spo tenant recyclebinitem list",
-        "Example": "Returns all modern and classic site collections in the tenant scoped recycle bin"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo sitedesign rights list",
-    "Description": "Gets a list of principals that have access to a site design",
-    "Options": "`-i, --siteDesignId <siteDesignId>`: The ID of the site design to get rights information from",
-    "Examples": [
-      {
-        "Description": "m365 spo sitedesign rights list --siteDesignId 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a",
-        "Example": "Get information about rights granted for the site design with ID 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo sitedesign run list",
-    "Description": "Lists information about site designs applied to the specified site",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site for which to list applied site designs`-i, --siteDesignId [siteDesignId]`: The ID of the site design for which to display information",
-    "Examples": [
-      {
-        "Description": "m365 spo sitedesign run list --webUrl https://contoso.sharepoint.com/sites/team-a",
-        "Example": "List site designs applied to the specified site"
-      },
-      {
-        "Description": "m365 spo sitedesign run list --webUrl https://contoso.sharepoint.com/sites/team-a --siteDesignId 6ec3ca5b-d04b-4381-b169-61378556d76e",
-        "Example": "List information about the specified site design applied to the specified site"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo site recyclebinitem list",
-    "Description": "Lists items from recycle bin",
-    "Options": "`-u, --siteUrl <siteUrl>`: URL of the site for which to retrieve the recycle bin items`--type [type]`: Type of items which should be retrieved (listItems, folders, files)`--secondary`: Use this switch to retrieve items from secondary recycle bin",
-    "Examples": [
-      {
-        "Description": "m365 spo site recyclebinitem list --siteUrl https://contoso.sharepoint.com/site",
-        "Example": "Lists all files, items and folders from recycle bin for site https://contoso.sharepoint.com/site"
-      },
-      {
-        "Description": "m365 spo site recyclebinitem list --siteUrl https://contoso.sharepoint.com/site --type files",
-        "Example": "Lists only files from recycle bin for site https://contoso.sharepoint.com/site"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo page section get",
-    "Description": "Get information about the specified modern page section",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.`-n, --pageName <pageName>`: Name of the page to get section information of.`-s, --section <sectionId>`: ID of the section for which to retrieve information.",
-    "Examples": [
-      {
-        "Description": "m365 spo page section get --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx --section 1",
-        "Example": "Get information about the specified section of the modern page"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo page column list",
-    "Description": "Lists columns in the specific section of a modern page",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the page to retrieve is located.`-n, --pageName <pageName>`: Name of the page to list columns of.`-s, --section <sectionId>`: ID of the section for which to list columns.",
-    "Examples": [
-      {
-        "Description": "m365 spo page column list --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx --section 1",
-        "Example": "List columns in the first section of a modern page"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo tenant applicationcustomizer list",
-    "Description": "Retrieves a list of application customizers that are installed tenant-wide",
-    "Options": null,
-    "Examples": [
-      {
-        "Description": "m365 spo tenant applicationcustomizer list",
-        "Example": "Retrieves a list of application customizers."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo site apppermission list",
-    "Description": "Lists application permissions for a site",
-    "Options": "`-u, --siteUrl <siteUrl>`: URL of the site collection to retrieve information for`-i, --appId [appId]`: Id of the application to filter by`-n, --appDisplayName [appDisplayName]`: Display name of the application to filter by",
-    "Examples": [
-      {
-        "Description": "m365 spo site apppermission list --siteUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Return list of application permissions for the https://contoso.sharepoint.com/sites/project-x site collection."
-      },
-      {
-        "Description": "m365 spo site apppermission list --siteUrl https://contoso.sharepoint.com/sites/project-x --appDisplayName Foo",
-        "Example": "Return list of application permissions for the https://contoso.sharepoint.com/sites/project-x site collection and filter by an application called Foo"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo hubsite get",
-    "Description": "Gets information about the specified hub site",
-    "Options": "`-i, --id [id]`: ID of the hub site. Specify either `id`, `title`, or `url` but not multiple.`-t, --title [title]`: Title of the hub site. Specify either `id`, `title`, or `url` but not multiple.`-u, --url [url]`: URL of the hub site. Specify either `id`, `title`, or `url` but not multiple.`--includeAssociatedSites`: Include the associated sites in the result (only in JSON output)",
-    "Examples": [
-      {
-        "Description": "m365 spo hubsite get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a",
-        "Example": "Get information about the hub site with specific ID."
-      },
-      {
-        "Description": "m365 spo hubsite get --title 'My Hub Site'",
-        "Example": "Get information about the hub site with specific title."
-      },
-      {
-        "Description": "m365 spo hubsite get --url 'https://contoso.sharepoint.com/sites/HubSite'",
-        "Example": "Get information about the hub site with specific URL."
-      },
-      {
-        "Description": "m365 spo hubsite get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a --includeAssociatedSites --output json",
-        "Example": "Get information about the hub site with specific ID, including its associated sites. Associated site info is only shown in JSON output."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo file version get",
-    "Description": "Gets information about a specific version of a specified file",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located`--label <label>`: Label of version which will be retrieved`--fileUrl [fileUrl]`: The server- or site-relative decoded URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both`-i, --fileId [fileId]`: The UniqueId (GUID) of the file to retrieve. Specify either `fileUrl` or `fileId` but not both",
-    "Examples": [
-      {
-        "Description": "m365 spo file version get --webUrl https://contoso.sharepoint.com --label \"1.0\" --fileId 'b2307a39-e878-458b-bc90-03bc578531d6'",
-        "Example": "Get file version in a specific site based on fileId"
-      },
-      {
-        "Description": "m365 spo file version get --webUrl https://contoso.sharepoint.com --label \"1.0\" --fileUrl '/Shared Documents/Document.docx'",
-        "Example": "Get file in a specific site based on fileUrl"
       }
     ]
   },
@@ -1753,378 +2421,228 @@ export const Commands = [
     ]
   },
   {
-    "Command": "m365 spo app get",
-    "Description": "Gets information about the specific app from the specified app catalog",
-    "Options": "`-i, --id [id]`: ID of the app to retrieve information for. Specify the `id` or the `name` but not both`-n, --name [name]`: Name of the app to retrieve information for. Specify the `id` or the `name` but not both`-u, --appCatalogUrl [appCatalogUrl]`: URL of the tenant or site collection app catalog. It must be specified when the scope is `sitecollection``-s, --appCatalogScope [appCatalogScope]`: Scope of the app catalog: `tenant,sitecollection`. Default `tenant`",
+    "Command": "m365 spo sitedesign get",
+    "Description": "Gets information about the specified site design",
+    "Options": "`-i, --id [id]`: Site design ID. Specify either `id` or `title` but not both.`--title [title]`: Site design title. Specify either `id` or `title` but not both.",
     "Examples": [
       {
-        "Description": "m365 spo app get --id b2307a39-e878-458b-bc90-03bc578531d6",
-        "Example": "Return details about the app with ID b2307a39-e878-458b-bc90-03bc578531d6 available in the tenant app catalog."
+        "Description": "m365 spo sitedesign get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a",
+        "Example": "Get information about the site design with ID 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a"
       },
       {
-        "Description": "m365 spo app get --name solution.sppkg",
-        "Example": "Return details about the app with name solution.sppkg available in the tenant app catalog. Will try to detect the app catalog URL"
-      },
-      {
-        "Description": "m365 spo app get --name solution.sppkg --appCatalogUrl https://contoso.sharepoint.com/sites/apps",
-        "Example": "Return details about the app with name solution.sppkg available in the tenant app catalog using the specified app catalog URL"
-      },
-      {
-        "Description": "m365 spo app get --id b2307a39-e878-458b-bc90-03bc578531d6 --appCatalogScope sitecollection --appCatalogUrl https://contoso.sharepoint.com/sites/site1",
-        "Example": "Return details about the app with ID b2307a39-e878-458b-bc90-03bc578531d6 available in the site collection app catalog of site https://contoso.sharepoint.com/sites/site1."
+        "Description": "m365 spo sitedesign get --title \"Contoso Site Design\"",
+        "Example": "Get information about the site design with title Contoso Site Design"
       }
     ]
   },
   {
-    "Command": "m365 spo customaction get",
-    "Description": "Gets information about a user custom action for site or site collection",
-    "Options": "`-i, --id [id]`: ID of the user custom action to retrieve information for. Specify either `id`, `title` or `clientSideComponentId``-t, --title [title]`: Title of the user custom action to retrieve information for. Specify either `id`, `title` or `clientSideComponentId``-c, --clientSideComponentId [clientSideComponentId]`: clientSideComponentId of the user custom action to retrieve information for. Specify either `id`, `title` or `clientSideComponentId``-u, --webUrl <webUrl>`: Url of the site or site collection to retrieve the custom action from`-s, --scope [scope]`: Scope of the custom action. Allowed values `Site`, `Web`, `All`. Default `All`",
+    "Command": "m365 spo web installedlanguage list",
+    "Description": "Lists all installed languages on site",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site for which to retrieve the list of installed languages",
     "Examples": [
       {
-        "Description": "m365 spo customaction get --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --webUrl https://contoso.sharepoint.com/sites/test",
-        "Example": "Return details about the user custom action based on the id and a given url"
-      },
-      {
-        "Description": "m365 spo customaction get --title \"YourAppCustomizer\" --webUrl https://contoso.sharepoint.com/sites/test",
-        "Example": "Return details about the user custom action based on the title and a given url"
-      },
-      {
-        "Description": "m365 spo customaction get --clientSideComponentId \"34a019f9-6198-4053-a3b6-fbdea9a107fd\" --webUrl https://contoso.sharepoint.com/sites/test",
-        "Example": "Return details about the user custom action based on the clientSideComponentId and a given url"
-      },
-      {
-        "Description": "m365 spo customaction get --id \"058140e3-0e37-44fc-a1d3-79c487d371a3\" --webUrl https://contoso.sharepoint.com/sites/test --scope Site",
-        "Example": "Return details about the user custom action based on the id and a given url and the scope"
-      },
-      {
-        "Description": null,
-        "Example": "m365 spo customaction get --id \"058140e3-0e37-44fc-a1d3-79c487d371a3\" --webUrl https://contoso.sharepoint.com/sites/test --scope Web"
+        "Description": "m365 spo web installedlanguage list --webUrl https://contoso.sharepoint.com",
+        "Example": "Return all installed languages from site https://contoso.sharepoint.com/"
       }
     ]
   },
   {
-    "Command": "m365 spo orgnewssite list",
-    "Description": "Lists all organizational news sites",
+    "Command": "m365 spo theme get",
+    "Description": "Gets custom theme information",
+    "Options": "`-n, --name <name>`: The name of the theme to retrieve",
+    "Examples": [
+      {
+        "Description": "m365 spo theme get --name Contoso-Blue",
+        "Example": "Get information about a theme"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo term group get",
+    "Description": "Gets information about the specified taxonomy term group",
+    "Options": "`-u, --webUrl [webUrl]`: If specified, allows you to get a term group from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.`-i, --id [id]`: ID of the term group to retrieve. Specify `name` or `id` but not both.`-n, --name [name]`: Name of the term group to retrieve. Specify `name` or `id` but not both.",
+    "Examples": [
+      {
+        "Description": "m365 spo term group get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb",
+        "Example": "Get information about a taxonomy term group using its ID."
+      },
+      {
+        "Description": "m365 spo term group get --name PnPTermSets",
+        "Example": "Get information about a taxonomy term group using its name."
+      },
+      {
+        "Description": "m365 spo term group get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Get information about a taxonomy term group from the specified sitecollection using its ID."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo site appcatalog list",
+    "Description": "List all site collection app catalogs within the tenant",
     "Options": null,
     "Examples": [
       {
-        "Description": "m365 spo orgnewssite list",
-        "Example": "List all organizational news sites"
+        "Description": "m365 spo site appcatalog list",
+        "Example": "List all site collection app catalogs within the tenant"
       }
     ]
   },
   {
-    "Command": "m365 spo contenttype list",
-    "Description": "Lists content types from specified site",
-    "Options": "`-u, --webUrl <webUrl>`: Absolute URL of the site for which to list content types`-c, --category [category]`: Category name of content types. When defined will return only content types from specified category",
+    "Command": "m365 spo roledefinition get",
+    "Description": "Gets specified role definition from web",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site for which to retrieve the role definition.`-i, --id <id>`: The Id of the role definition to retrieve.",
     "Examples": [
       {
-        "Description": "`-u, --webUrl <webUrl>`",
-        "Example": "Retrieve site content types"
+        "Description": "m365 spo roledefinition get --webUrl https://contoso.sharepoint.com/sites/project-x --id 1",
+        "Example": "Retrieve the role definition for the given site"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo sitedesign run status get",
+    "Description": "Gets information about the site scripts executed for the specified site design",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site for which to get the information`-i, --runId <runId>`: ID of the site design applied to the site as retrieved using `spo sitedesign run list`",
+    "Examples": [
+      {
+        "Description": "m365 spo sitedesign run status get --webUrl https://contoso.sharepoint.com/sites/team-a --runId b4411557-308b-4545-a3c4-55297d5cd8c8",
+        "Example": "List information about site scripts executed for the specified site design"
+      }
+    ]
+  },
+  {
+    "Command": "m365 teams messagingsettings list",
+    "Description": "Lists messaging settings for a Microsoft Teams team",
+    "Options": "`-i, --teamId`: The ID of the team for which to get the messaging settings.",
+    "Examples": [
+      {
+        "Description": "m365 teams messagingsettings list --teamId 2609af39-7775-4f94-a3dc-0dd67657e900",
+        "Example": "Get messaging settings for a Microsoft Teams team."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo customaction list",
+    "Description": "Lists user custom actions for site or site collection",
+    "Options": "`-u, --webUrl <webUrl>`: Url of the site or site collection to retrieve the custom action from`-s, --scope [scope]`: Scope of the custom action. Allowed values `Site`, `Web`, `All`. Default `All`",
+    "Examples": [
+      {
+        "Description": "m365 spo customaction list --webUrl https://contoso.sharepoint.com/sites/test",
+        "Example": "Return details about all user custom actions located in site or site collection https://contoso.sharepoint.com/sites/test"
       },
       {
-        "Description": "`-c, --category [category]`",
-        "Example": ": Absolute URL of the site for which to list content types"
+        "Description": "m365 spo customaction list --webUrl https://contoso.sharepoint.com/sites/test --scope Site",
+        "Example": "Return details about all user custom actions located in site collection https://contoso.sharepoint.com/sites/test"
       },
       {
-        "Description": "`-u, --webUrl <webUrl>`",
-        "Example": ": Category name of content types. When defined will return only content types from specified category"
+        "Description": "m365 spo customaction list --webUrl https://contoso.sharepoint.com/sites/test --scope Web",
+        "Example": "Return details about all user custom actions located in site https://contoso.sharepoint.com/sites/test"
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo term set list",
+    "Description": "Lists taxonomy term sets from the given term group",
+    "Options": "`-u, --webUrl [webUrl]`: If specified, allows you to list term sets from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.`--termGroupId [termGroupId]`: ID of the term group from which to retrieve term sets. Specify `termGroupName` or `termGroupId` but not both.`--termGroupName [termGroupName]`: Name of the term group from which to retrieve term sets. Specify `termGroupName` or `termGroupId` but not both.",
+    "Examples": [
+      {
+        "Description": "m365 spo term set list --termGroupName PnPTermSets",
+        "Example": "List taxonomy term sets from the term group with the given name."
+      },
+      {
+        "Description": "m365 spo term set list --termGroupId 0e8f395e-ff58-4d45-9ff7-e331ab728beb",
+        "Example": "List taxonomy term sets from the term group with the given ID."
+      },
+      {
+        "Description": "m365 spo term set list --termGroupName PnPTermSets --webUrl https://contoso.sharepoint.com/sites/project-x",
+        "Example": "List taxonomy term sets from the specified sitecollection, from the term group with the given name."
+      }
+    ]
+  },
+  {
+    "Command": "m365 spo file sharinginfo get",
+    "Description": "Generates a sharing information report for the specified file",
+    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located`--fileUrl [fileUrl]`: The server- or site-relative decoded URL of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both`-i, --fileId [fileId]`: The UniqueId (GUID) of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both",
+    "Examples": [
+      {
+        "Description": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located",
+        "Example": "Get file sharing information report for the file with server-relative url /sites/M365CLI/Shared Documents/SharedFile.docx located in site https://contoso.sharepoint.com/sites/project-x"
+      },
+      {
+        "Description": ": The server- or site-relative decoded URL of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both",
+        "Example": "`--fileUrl [fileUrl]`"
+      },
+      {
+        "Description": ": The UniqueId (GUID) of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both",
+        "Example": "`-i, --fileId [fileId]`"
+      },
+      {
+        "Description": ": The URL of the site where the file is located",
+        "Example": "`-u, --webUrl <webUrl>`"
+      },
+      {
+        "Description": "`--fileUrl [fileUrl]`",
+        "Example": ""
       },
       {
         "Description": "",
-        "Example": ": Absolute URL of the site for which to list content types"
+        "Example": ": The server- or site-relative decoded URL of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both"
       },
       {
-        "Description": ": Category name of content types. When defined will return only content types from specified category",
-        "Example": "`-c, --category [category]`"
+        "Description": ": The UniqueId (GUID) of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both",
+        "Example": "`-i, --fileId [fileId]`"
       },
       {
-        "Description": "Lists content types from specified site",
-        "Example": "m365 spo contenttype list [options]"
+        "Description": "Generates a sharing information report for the specified file",
+        "Example": "m365 spo file sharinginfo get [options]"
       },
       {
-        "Description": "m365 spo contenttype list --webUrl \"https://contoso.sharepoint.com/sites/contoso-sales\" --category \"List Content Types\"",
+        "Description": "m365 spo file sharinginfo get --webUrl https://contoso.sharepoint.com/sites/project-x --fileId \"b2307a39-e878-458b-bc90-03bc578531d6\"",
         "Example": "import Global from '/docs/cmd/_global.mdx';"
       }
     ]
   },
   {
-    "Command": "m365 spo sitescript list",
-    "Description": "Lists site script available for use with site designs",
-    "Options": null,
+    "Command": "m365 spo term list",
+    "Description": "Lists taxonomy terms from the given term set",
+    "Options": "`-u, --webUrl [webUrl]`: If specified, allows you to list terms from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.`--termGroupId [termGroupId]`: ID of the term group where the term set is located. Specify `termGroupId` or `termGroupName` but not both.`--termGroupName [termGroupName]`: Name of the term group where the term set is located. Specify `termGroupId` or `termGroupName` but not both.`--termSetId [termSetId]`: ID of the term set for which to retrieve terms. Specify `termSetId` or `termSetName` but not both.`--termSetName [termSetName]`: Name of the term set for which to retrieve terms. Specify `termSetId` or `termSetName` but not both.`--includeChildTerms`: If specified, child terms are loaded as well.",
     "Examples": [
       {
-        "Description": "m365 spo sitescript list",
-        "Example": "List all site scripts available for use with site designs"
+        "Description": "m365 spo term list --webUrl https://contoso.sharepoint.com/sites/project-x --termGroupName PnPTermSets --termSetName PnP-Organizations",
+        "Example": "List taxonomy terms from the specified sitecollection, the term group and term set with the given name"
+      },
+      {
+        "Description": "m365 spo term list --termGroupName PnPTermSets --termSetName PnP-Organizations",
+        "Example": "List taxonomy terms from the term group and term set with the given name."
+      },
+      {
+        "Description": "m365 spo term list --termGroupId 0e8f395e-ff58-4d45-9ff7-e331ab728beb --termSetId 0e8f395e-ff58-4d45-9ff7-e331ab728bec",
+        "Example": "List taxonomy terms from the term group and term set with the given ID."
+      },
+      {
+        "Description": "m365 spo term list --termGroupId 0e8f395e-ff58-4d45-9ff7-e331ab728beb --termSetId 0e8f395e-ff58-4d45-9ff7-e331ab728bec --includeChildTerms",
+        "Example": "List taxonomy terms from the term group and term set with the given ID including child terms if any are found."
       }
     ]
   },
   {
-    "Command": "m365 spo file version list",
-    "Description": "Retrieves all versions of a file",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the file is located`--fileUrl [fileUrl]`: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both`-i, --fileId [fileId]`: The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both",
+    "Command": "m365 spo sitedesign rights list",
+    "Description": "Gets a list of principals that have access to a site design",
+    "Options": "`-i, --siteDesignId <siteDesignId>`: The ID of the site design to get rights information from",
     "Examples": [
       {
-        "Description": "m365 spo file version list --webUrl https://contoso.sharepoint.com --fileId 'b2307a39-e878-458b-bc90-03bc578531d6'",
-        "Example": "List file versions of a specific file based on the ID of the file"
-      },
-      {
-        "Description": "m365 spo file version list --webUrl https://contoso.sharepoint.com --fileUrl '/Shared Documents/Document.docx'",
-        "Example": "List file versions of a specific file based on the site-relative URL of the file"
-      },
-      {
-        "Description": "m365 spo file version list --webUrl https://contoso.sharepoint.com/sites/project-x --fileUrl '/sites/project-x/Shared Documents/Document.docx'",
-        "Example": "List file versions of a specific file based on the server-relative URL of the file"
+        "Description": "m365 spo sitedesign rights list --siteDesignId 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a",
+        "Example": "Get information about rights granted for the site design with ID 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a"
       }
     ]
   },
   {
-    "Command": "m365 spo list webhook list",
-    "Description": "Lists all webhooks for the specified list",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list is located.`-i, --listId [listId]`: ID of the list. Specify either `listTitle`, `listId` or `listUrl`.`-t, --listTitle [listTitle]`: Title of the list. Specify either `listTitle`, `listId` or `listUrl`.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`.",
+    "Command": "m365 spo page template list",
+    "Description": "Lists all page templates in the given site",
+    "Options": "`-u, --webUrl <webUrl>`: URL of the site from which to retrieve available pages.",
     "Examples": [
       {
-        "Description": "m365 spo list webhook list --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf",
-        "Example": "List all webhooks for a list with a specific ID in a specific site"
-      },
-      {
-        "Description": "m365 spo list webhook list --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle Documents",
-        "Example": "List all webhooks for a list with a specific title in a specific site"
-      },
-      {
-        "Description": "m365 spo list webhook list --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl '/sites/project-x/Documents'",
-        "Example": "List all webhooks for a list with a specific URL in a specific site"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo feature list",
-    "Description": "Lists Features activated in the specified site or site collection",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site (collection) to retrieve the activated Features from`-s, --scope [scope]`: Scope of the Features to retrieve. Allowed values `Site,Web`. Default `Web`",
-    "Examples": [
-      {
-        "Description": "`-u, --webUrl <webUrl>`",
-        "Example": "Return details about Features activated in the specified site collection"
-      },
-      {
-        "Description": "`-s, --scope [scope]`",
-        "Example": ": URL of the site (collection) to retrieve the activated Features from"
-      },
-      {
-        "Description": "`-u, --webUrl <webUrl>`",
-        "Example": ": Scope of the Features to retrieve. Allowed values `Site,Web`. Default `Web`"
-      },
-      {
-        "Description": "",
-        "Example": ": URL of the site (collection) to retrieve the activated Features from"
-      },
-      {
-        "Description": ": Scope of the Features to retrieve. Allowed values `Site,Web`. Default `Web`",
-        "Example": "`-s, --scope [scope]`"
-      },
-      {
-        "Description": "Lists Features activated in the specified site or site collection",
-        "Example": "m365 spo feature list [options]"
-      },
-      {
-        "Description": "m365 spo feature list --webUrl https://contoso.sharepoint.com/sites/test --scope Web",
-        "Example": "import Global from '/docs/cmd/_global.mdx';"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo term set get",
-    "Description": "Gets information about the specified taxonomy term set",
-    "Options": "`-u, --webUrl [webUrl]`: If specified, allows you to get a term set from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.`-i, --id [id]`: ID of the term set to retrieve. Specify `name` or `id` but not both.`-n, --name [name]`: Name of the term set to retrieve. Specify `name` or `id` but not both.`--termGroupId [termGroupId]`: ID of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both.`--termGroupName [termGroupName]`: Name of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both.",
-    "Examples": [
-      {
-        "Description": "m365 spo term set get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb --termGroupName PnPTermSets",
-        "Example": "Get information about a taxonomy term set using its ID."
-      },
-      {
-        "Description": "m365 spo term set get --name PnP-Organizations --termGroupId 0a099ee9-e231-4ae9-a5b6-d7f94a0d241d",
-        "Example": "Get information about a taxonomy term set using its name."
-      },
-      {
-        "Description": "m365 spo term set get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb --termGroupName PnPTermSets --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Get information about a taxonomy term set using its ID from the specified sitecollection."
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo sitedesign task get",
-    "Description": "Gets information about the specified site design scheduled for execution",
-    "Options": "`-i, --id <id>`: The ID of the site design task to get information for",
-    "Examples": [
-      {
-        "Description": "m365 spo sitedesign task get --id 6ec3ca5b-d04b-4381-b169-61378556d76e",
-        "Example": "Get information about the specified site design scheduled for execution"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo sitescript get",
-    "Description": "Gets information about the specified site script",
-    "Options": "`-i, --id <id>`: Site script ID",
-    "Examples": [
-      {
-        "Description": "m365 spo sitescript get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a",
-        "Example": "Get information about the site script with ID 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo roledefinition list",
-    "Description": "Gets list of role definitions for the specified site",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site for which to retrieve role definitions.",
-    "Examples": [
-      {
-        "Description": "m365 spo roledefinition list --webUrl https://contoso.sharepoint.com/sites/project-x",
-        "Example": "Return list of role definitions for the given site"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo externaluser list",
-    "Description": "Lists external users in the tenant",
-    "Options": "`--filter [filter]`: Limits the results to only those users whose first name, last name or email address begins with the text in the string, using a case-insensitive comparison`-p, --pageSize [pageSize]`: Specifies the maximum number of users to be returned in the collection. The value must be less than or equal to `50``-i, --position [position]`: Use to specify the zero-based index of the position in the sorted collection of the first result to be returned`-s, --sortOrder [sortOrder]`: Specifies the sort results in Ascending or Descending order on the `SPOUser.Email` property should occur. Allowed values `asc|desc`. Default `asc``-u, --siteUrl [siteUrl]`: Specifies the site to retrieve external users for. If no site is specified, the external users for all sites are returned",
-    "Examples": [
-      {
-        "Description": "To use this command you have to have permissions to access the tenant admin site.",
-        "Example": "List all external users from the current tenant. Show the first batch of 50 users."
-      },
-      {
-        "Description": ": Limits the results to only those users whose first name, last name or email address begins with the text in the string, using a case-insensitive comparison",
-        "Example": "`--filter [filter]`"
-      },
-      {
-        "Description": ": Specifies the maximum number of users to be returned in the collection. The value must be less than or equal to `50`",
-        "Example": "`-p, --pageSize [pageSize]`"
-      },
-      {
-        "Description": ": Use to specify the zero-based index of the position in the sorted collection of the first result to be returned",
-        "Example": "`-i, --position [position]`"
-      },
-      {
-        "Description": ": Specifies the sort results in Ascending or Descending order on the `SPOUser.Email` property should occur. Allowed values `asc|desc`. Default `asc`",
-        "Example": "`-s, --sortOrder [sortOrder]`"
-      },
-      {
-        "Description": ": Specifies the site to retrieve external users for. If no site is specified, the external users for all sites are returned",
-        "Example": "`-u, --siteUrl [siteUrl]`"
-      },
-      {
-        "Description": ": Limits the results to only those users whose first name, last name or email address begins with the text in the string, using a case-insensitive comparison",
-        "Example": "`--filter [filter]`"
-      },
-      {
-        "Description": "`-p, --pageSize [pageSize]`",
-        "Example": ""
-      },
-      {
-        "Description": "",
-        "Example": ": Specifies the maximum number of users to be returned in the collection. The value must be less than or equal to `50`"
-      },
-      {
-        "Description": ": Use to specify the zero-based index of the position in the sorted collection of the first result to be returned",
-        "Example": "`-i, --position [position]`"
-      },
-      {
-        "Description": "`-s, --sortOrder [sortOrder]`",
-        "Example": ""
-      },
-      {
-        "Description": "",
-        "Example": ": Specifies the sort results in Ascending or Descending order on the `SPOUser.Email` property should occur. Allowed values `asc|desc`. Default `asc`"
-      },
-      {
-        "Description": ": Specifies the site to retrieve external users for. If no site is specified, the external users for all sites are returned",
-        "Example": "`-u, --siteUrl [siteUrl]`"
-      },
-      {
-        "Description": "Lists external users in the tenant",
-        "Example": "m365 spo externaluser list [options]"
-      },
-      {
-        "Description": "m365 spo externaluser list --pageSize 50 --position 0 --sortOrder desc",
-        "Example": "import Global from '/docs/cmd/_global.mdx';"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo cdn origin list",
-    "Description": "List CDN origins settings for the current SharePoint Online tenant",
-    "Options": "`-t, --type [type]`: Type of CDN to manage. `Public,Private`. Default `Public`",
-    "Examples": [
-      {
-        "Description": "m365 spo cdn origin list",
-        "Example": "Show the list of origins configured for the Public CDN"
-      },
-      {
-        "Description": "m365 spo cdn origin list --type Private",
-        "Example": "Show the list of origins configured for the Private CDN"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo list webhook get",
-    "Description": "Gets information about the specific webhook",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the site where the list is located.`-l, --listId [listId]`: ID of the list. Specify either `listTitle`, `listId` or `listUrl`.`-t, --listTitle [listTitle]`: Title of the list. Specify either `listTitle`, `listId` or `listUrl`.`--listUrl [listUrl]`: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`.`-i, --id <id>`: ID of the webhook.",
-    "Examples": [
-      {
-        "Description": "m365 spo list webhook get --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf --id cc27a922-8224-4296-90a5-ebbc54da2e85",
-        "Example": "Return information about a specific webhook which belongs to a list retrieved by ID in a specific site"
-      },
-      {
-        "Description": "m365 spo list webhook get --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle Documents --id cc27a922-8224-4296-90a5-ebbc54da2e85",
-        "Example": "Return information about a specific webhook which belongs to a list retrieved by Title in a specific site"
-      },
-      {
-        "Description": "m365 spo list webhook get --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl '/sites/project-x/Documents' --id cc27a922-8224-4296-90a5-ebbc54da2e85",
-        "Example": "Return information about a specific webhook which belongs to a list retrieved by URL in a specific site"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo group member list",
-    "Description": "List the members of a SharePoint Group",
-    "Options": "`-u, --webUrl <webUrl>`: URL of the SharePoint site`--groupId [groupId]`: Id of the SharePoint group. Use either `groupName` or `groupId`, but not both`--groupName [groupName]`: Name of the SharePoint group. Use either `groupName` or `groupId`, but not both",
-    "Examples": [
-      {
-        "Description": "`-u, --webUrl <webUrl>`: URL of the SharePoint site`--groupId [groupId]`",
-        "Example": "List the members of the group with ID 5 for web https://contoso.sharepoint.com/sites/SiteA"
-      },
-      {
-        "Description": "`--groupName [groupName]`",
-        "Example": ": Id of the SharePoint group. Use either `groupName` or `groupId`, but not both"
-      },
-      {
-        "Description": "`-u, --webUrl <webUrl>`",
-        "Example": ": Name of the SharePoint group. Use either `groupName` or `groupId`, but not both"
-      },
-      {
-        "Description": "",
-        "Example": ": URL of the SharePoint site"
-      },
-      {
-        "Description": ": Id of the SharePoint group. Use either `groupName` or `groupId`, but not both",
-        "Example": "`--groupId [groupId]`"
-      },
-      {
-        "Description": "`--groupName [groupName]`",
-        "Example": ""
-      },
-      {
-        "Description": "m365 spo group member list [options]",
-        "Example": ": Name of the SharePoint group. Use either `groupName` or `groupId`, but not both"
-      },
-      {
-        "Description": "import Global from '/docs/cmd/_global.mdx';",
-        "Example": "List the members of a SharePoint Group"
-      },
-      {
-        "Description": null,
-        "Example": "m365 spo group member list --webUrl https://contoso.sharepoint.com/sites/SiteA --groupName \"Contoso Site Members\""
+        "Description": "m365 spo page template list --webUrl https://contoso.sharepoint.com/sites/team-a",
+        "Example": "Lists all page templates in the given site"
       }
     ]
   },
@@ -2148,140 +2666,28 @@ export const Commands = [
     ]
   },
   {
-    "Command": "m365 spo navigation node list",
-    "Description": "Lists nodes from the specified site navigation",
-    "Options": "`-u, --webUrl <webUrl>`: Absolute URL of the site for which to retrieve navigation`-l, --location <location>`: Navigation type to retrieve. Available options: `QuickLaunch,TopNavigationBar`",
+    "Command": "m365 spo site get",
+    "Description": "Gets information about the specific site collection",
+    "Options": "`-u, --url <url>`: URL of the site collection to retrieve information for",
     "Examples": [
       {
-        "Description": "m365 spo navigation node list --webUrl https://contoso.sharepoint.com/sites/team-a --location TopNavigationBar",
-        "Example": "Retrieve nodes from the top navigation"
-      },
-      {
-        "Description": "m365 spo navigation node list --webUrl https://contoso.sharepoint.com/sites/team-a --location QuickLaunch",
-        "Example": "Retrieve nodes from the quick launch"
+        "Description": "m365 spo site get -u https://contoso.sharepoint.com/sites/project-x",
+        "Example": "Return information about the https://contoso.sharepoint.com/sites/project-x site collection."
       }
     ]
   },
   {
-    "Command": "m365 spo theme get",
-    "Description": "Gets custom theme information",
-    "Options": "`-n, --name <name>`: The name of the theme to retrieve",
+    "Command": "m365 teams meeting attendancereport list",
+    "Description": "Lists all attendance reports for a given meeting",
+    "Options": "`-u, --userId [userId]`: The id of the user, omit to list attendance reports for current signed in user. Use either  `id`, `userName` or `email`, but not multiple.`-n, --userName [userName]`: The name of the user, omit to list attendance reports for current signed in user. Use either `id`, `userName` or `email`, but not multiple.`--email [email]`: The email of the user, omit to list attendance reports for current signed in user. Use either `id`, `userName` or `email`, but not multiple.`-m, --meetingId <meetingId>`: The Id of the meeting.",
     "Examples": [
       {
-        "Description": "m365 spo theme get --name Contoso-Blue",
-        "Example": "Get information about a theme"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo file list",
-    "Description": "Gets all files within the specified folder and site",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the folder from which to retrieve files is located.`--folderUrl <folderUrl>`: The server- or site-relative decoded URL of the parent folder from which to retrieve files.`--fields [fields]`: Comma-separated list of fields to retrieve. Will retrieve all fields if not specified.`--filter [filter]`: OData filter to use to query the list of items with.`-r, --recursive`: Set to retrieve files from subfolders.",
-    "Examples": [
-      {
-        "Description": "m365 spo file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents'",
-        "Example": "Return all files from a folder"
+        "Description": "m365 teams meeting attendancereport list --meetingId MSo4NmY0MWZhMi1kYjUxLTQyMTUtYjE3Zi1lYzY3NGQ2MjQzNjYqMCoqMTk6bWVldGluZ19OamMwWW1Zd05UVXROMlJoTlMwME0yRmhMV0V6T1RndE9HVmxNbVl4TkdVd05tUTNAdGhyZWFkLnYy",
+        "Example": "Lists all attendance reports made for the current signed in user and Microsoft Teams meeting with given id"
       },
       {
-        "Description": "m365 spo file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents' --recursive",
-        "Example": "Return all files from a folder and all the sub-folders"
-      },
-      {
-        "Description": "m365 spo file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents' --fields \"Title,Length\"",
-        "Example": "Return the files from a folder with specific fields which will be expanded"
-      },
-      {
-        "Description": "m365 spo file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents' --fields ListItemAllFields/Id --filter \"Name eq 'document.docx'\"",
-        "Example": "Return the files from a folder that meet the criteria of the filter with specific fields which will be expanded"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo site appcatalog list",
-    "Description": "List all site collection app catalogs within the tenant",
-    "Options": null,
-    "Examples": [
-      {
-        "Description": "m365 spo site appcatalog list",
-        "Example": "List all site collection app catalogs within the tenant"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo folder get",
-    "Description": "Gets information about the specified folder",
-    "Options": "`-u, --webUrl <webUrl>`: The URL of the site where the folder is located.`--url [url]`: The server- or site-relative decoded URL of the folder to retrieve. Specify either `folderUrl` or `id` but not both.`-i, --id [id]`: The UniqueId (GUID) of the folder to retrieve. Specify either `url` or `id` but not both.`--withPermissions`: Set if you want to return associated roles and permissions of the folder. ",
-    "Examples": [
-      {
-        "Description": "Please ensure the specified folder URL or folder Id does not refer to a root folder. Use \\'spo list get\\' with withPermissions instead' error.",
-        "Example": "Get folder properties for a folder with a specific site-relative URL"
-      },
-      {
-        "Description": "Please check the folder URL. Folder might not exist on the specified URL",
-        "Example": "If root level folder is passed, you will get a Please ensure the specified folder URL or folder Id does not refer to a root folder. Use \\'spo list get\\' with withPermissions instead' error. Please use the command 'spo list get'."
-      },
-      {
-        "Description": "`-u, --webUrl <webUrl>`: The URL of the site where the folder is located.",
-        "Example": "If no folder exists at the specified URL, you will get a Please check the folder URL. Folder might not exist on the specified URL error."
-      },
-      {
-        "Description": ": The server- or site-relative decoded URL of the folder to retrieve. Specify either `folderUrl` or `id` but not both.",
-        "Example": "`--url [url]`"
-      },
-      {
-        "Description": ": The UniqueId (GUID) of the folder to retrieve. Specify either `url` or `id` but not both.",
-        "Example": "`-i, --id [id]`"
-      },
-      {
-        "Description": ": Set if you want to return associated roles and permissions of the folder. ",
-        "Example": "`--withPermissions`"
-      },
-      {
-        "Description": ": The URL of the site where the folder is located.",
-        "Example": "`-u, --webUrl <webUrl>`"
-      },
-      {
-        "Description": "`--url [url]`",
-        "Example": ""
-      },
-      {
-        "Description": "",
-        "Example": ": The server- or site-relative decoded URL of the folder to retrieve. Specify either `folderUrl` or `id` but not both."
-      },
-      {
-        "Description": ": The UniqueId (GUID) of the folder to retrieve. Specify either `url` or `id` but not both.",
-        "Example": "`-i, --id [id]`"
-      },
-      {
-        "Description": "`--withPermissions`",
-        "Example": ""
-      },
-      {
-        "Description": "m365 spo folder get [options]",
-        "Example": ": Set if you want to return associated roles and permissions of the folder. "
-      },
-      {
-        "Description": "import Global from '/docs/cmd/_global.mdx';",
-        "Example": "Gets information about the specified folder"
-      },
-      {
-        "Description": null,
-        "Example": "m365 spo folder get --webUrl https://contoso.sharepoint.com/sites/test --url \"/sites/test/Shared Documents/Test1\" --withPermissions"
-      }
-    ]
-  },
-  {
-    "Command": "m365 spo cdn get",
-    "Description": "View current status of the specified Microsoft 365 CDN",
-    "Options": "`-t, --type [type]`: Type of CDN to manage. Allowed values `Public`, `Private`. Default `Public`.",
-    "Examples": [
-      {
-        "Description": "m365 spo cdn get",
-        "Example": "Show if the Public CDN is currently enabled or not."
-      },
-      {
-        "Description": "m365 spo cdn get --type Private",
-        "Example": "Show if the Private CDN is currently enabled or not."
+        "Description": "m365 teams meeting attendancereport list --userName garthf@contoso.com --meetingId MSo4NmY0MWZhMi1kYjUxLTQyMTUtYjE3Zi1lYzY3NGQ2MjQzNjYqMCoqMTk6bWVldGluZ19OamMwWW1Zd05UVXROMlJoTlMwME0yRmhMV0V6T1RndE9HVmxNbVl4TkdVd05tUTNAdGhyZWFkLnYy",
+        "Example": "Lists all attendance reports made for the garthf@contoso.com and Microsoft Teams meeting with given id"
       }
     ]
   }

--- a/src/chat/PromptHandlers.ts
+++ b/src/chat/PromptHandlers.ts
@@ -66,8 +66,14 @@ export class PromptHandlers {
           }
         } catch (err: any) {
           Logger.getInstance();
-          Logger.error(err!.error ? err!.error.message.toString() : err.toString());
+          const errorText = err!.error ? err!.error.message.toString() : err.toString();
+          Logger.error(errorText);
           stream.markdown('\n\nI was not able to retrieve the data from SharePoint. Please check the logs in output window for more information.');
+
+          const markdownString = new vscode.MarkdownString();
+          markdownString.supportHtml = true;
+          markdownString.appendMarkdown(`<span style="color:#f00;">${errorText}</span>`);
+          stream.markdown(markdownString);
         }
       }
 

--- a/src/chat/PromptHandlers.ts
+++ b/src/chat/PromptHandlers.ts
@@ -92,7 +92,7 @@ export class PromptHandlers {
   }
 
   private static async tryToGetDataFromSharePoint(chatResponse: string): Promise<string | undefined> {
-    const cliRegex = /```([^\n]*)\n(?=[\s\S]*?m365 spo.+)([\s\S]*?)\n?```/g;
+    const cliRegex = /```([^\n]*)\n(?=[\s\S]*?m365.+)([\s\S]*?)\n?```/g;
     const cliMatch = cliRegex.exec(chatResponse);
 
     if (cliMatch && cliMatch[2]) {
@@ -132,6 +132,9 @@ export class PromptHandlers {
         context += promptMangeContext;
         if (EnvironmentInformation.tenantUrl) {
           context += `Tenant SharePoint URL is: ${EnvironmentInformation.tenantUrl}`;
+        }
+        if (EnvironmentInformation.account) {
+          context += `Current userName (account) is: ${EnvironmentInformation.account}`;
         }
       default:
         context += promptGeneralContext;

--- a/src/constants/Commands.ts
+++ b/src/constants/Commands.ts
@@ -60,5 +60,8 @@ export const Commands = {
   enableAppCatalogApp: `${EXTENSION_NAME}.enableAppCatalogApp`,
   disableAppCatalogApp: `${EXTENSION_NAME}.disableAppCatalogApp`,
   upgradeAppCatalogApp: `${EXTENSION_NAME}.upgradeAppCatalogApp`,
-  showMoreActions: `${EXTENSION_NAME}.showMoreActions`
+  showMoreActions: `${EXTENSION_NAME}.showMoreActions`,
+
+  // Set form customizer
+  setFormCustomizer: `${EXTENSION_NAME}.setFormCustomizer`
 };

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -310,6 +310,7 @@ export class CommandPanel {
 
     actionCommands.push(new ActionTreeItem('Add new component', '', { name: 'add', custom: false }, undefined, Commands.addToProject));
     actionCommands.push(new ActionTreeItem('Scaffold CI/CD Workflow', '', { name: 'rocket', custom: false }, undefined, Commands.pipeline));
+    actionCommands.push(new ActionTreeItem('Set Form Customizer', '', { name: 'checklist', custom: false }, undefined, Commands.setFormCustomizer));
     actionCommands.push(new ActionTreeItem('View samples', '', { name: 'library', custom: false }, undefined, Commands.samplesGallery));
 
     window.registerTreeDataProvider('pnp-view-actions', new ActionTreeDataProvider(actionCommands));

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -443,7 +443,7 @@ export class CliActions {
 
       await window.withProgress({
         location: ProgressLocation.Notification,
-        title: 'Creating app registration...',
+        title: `Creating app registration... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
         cancellable: true
       }, async (progress: Progress<{ message?: string; increment?: number }>) => {
         try {
@@ -481,7 +481,7 @@ export class CliActions {
 
     await window.withProgress({
       location: ProgressLocation.Notification,
-      title: `Generating ${input.workflowType === WorkflowType.gitHub ? 'GitHub Workflow' : 'Azure DevOps Pipeline'}...`,
+      title: `Generating ${input.workflowType === WorkflowType.gitHub ? 'GitHub Workflow' : 'Azure DevOps Pipeline'}... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
       cancellable: true
     }, async (progress: Progress<{ message?: string; increment?: number }>) => {
       try {
@@ -575,7 +575,7 @@ export class CliActions {
 
     await window.withProgress({
       location: ProgressLocation.Notification,
-      title: 'Generating the upgrade steps...',
+      title: `Generating the upgrade steps... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
       cancellable: true
     }, async (progress: Progress<{ message?: string; increment?: number }>) => {
       try {
@@ -641,7 +641,7 @@ export class CliActions {
 
     await window.withProgress({
       location: ProgressLocation.Notification,
-      title: 'Renaming the current project...',
+      title: `Renaming the current project... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
       cancellable: true
     }, async (progress: Progress<{ message?: string; increment?: number }>) => {
       try {
@@ -693,7 +693,7 @@ export class CliActions {
 
     await window.withProgress({
       location: ProgressLocation.Notification,
-      title: 'Granting API permissions for the current project...',
+      title: `Granting API permissions for the current project... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
       cancellable: true
     }, async (progress: Progress<{ message?: string; increment?: number }>) => {
       try {
@@ -749,7 +749,7 @@ export class CliActions {
 
     await window.withProgress({
       location: ProgressLocation.Notification,
-      title: 'Validating the current project...',
+      title: `Validating the current project... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
       cancellable: true
     }, async (progress: Progress<{ message?: string; increment?: number }>) => {
       try {
@@ -1014,7 +1014,7 @@ export class CliActions {
 
     await window.withProgress({
       location: ProgressLocation.Notification,
-      title: 'Setting form customizer...',
+      title: `Setting form customizer... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
       cancellable: true
     }, async (progress: Progress<{ message?: string; increment?: number }>) => {
       try {


### PR DESCRIPTION
## 🎯 Aim

The aim is to extend the list of supported commands/skills with teams area

The biggest problem I see with this is that we need to extend the SPFx Toolkit app reg with additional scopes which are needed only for this functionality. I am not sure if this is a bit of over kill for this tool

## 📷 Result

![image](https://github.com/user-attachments/assets/8fd22696-a360-4f70-9c57-3b3cbdffc91b)

![image](https://github.com/user-attachments/assets/38236206-4d1c-4b1e-bd26-031ad005d67b)

![image](https://github.com/user-attachments/assets/5b9b8c35-b397-4dcc-8a7b-cd140f6c9123)


## ✅ What was done

- [X] Added more commands
- [X] Small update in the chat handler
- [ ] Extend docs with additional scopes

## 🔗 Related

https://github.com/Adam-it/cli-microsoft365/commit/1fef118f9ca099023434bd98cce5fd0a95d8d3d2
