### PR TITLE
refactor tenant wide extensions for app catalog toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,10 +190,10 @@
 					"description": "Show the service health incidents in the account view."
 				},
 				"spfx-toolkit.showTenantWideExtensions": {
-					"title": "Show tenant-wide extensions",
+					"title": "Show apps in app catalogs",
 					"type": "boolean",
 					"default": true,
-					"description": "Show the tenant-wide extensions in the account view."
+					"description": "When set it will load all apps in every app catalog on your tenant."
 				},
 				"spfx-toolkit.createNodeVersionFileDefaultValue": {
 					"title": "Default value for the Node version file option",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
 					"default": true,
 					"description": "Show the service health incidents in the account view."
 				},
-				"spfx-toolkit.showTenantWideExtensions": {
+				"spfx-toolkit.showAppsInAppCatalogs": {
 					"title": "Show apps in app catalogs",
 					"type": "boolean",
 					"default": true,

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
 					"title": "Show apps in app catalogs",
 					"type": "boolean",
 					"default": true,
-					"description": "When set it will load all apps in every app catalog on your tenant."
+					"description": "When set it will load all apps in every app catalog from your tenant."
 				},
 				"spfx-toolkit.createNodeVersionFileDefaultValue": {
 					"title": "Default value for the Node version file option",

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -171,31 +171,36 @@ export class CommandPanel {
 
       const catalogItems: ActionTreeItem[] = [];
 
-      const showTenantWideExtensions: boolean = getExtensionSettings<boolean>('showTenantWideExtensions', true);
-      if (showTenantWideExtensions === true) {
-        const tenantWideExtensionsNode = new ActionTreeItem('Tenant-wide Extensions', '', { name: 'spo-app-list', custom: true }, TreeItemCollapsibleState.Collapsed, undefined, undefined, 'sp-app-catalog-tenant-wide-extensions', undefined,
-          async () => {
-            const tenantWideExtensions = await CliActions.getTenantWideExtensions(tenantAppCatalogUrl);
-            const tenantWideExtensionsList: ActionTreeItem[] = [];
+      const tenantWideExtensionsNode = new ActionTreeItem('Tenant-wide Extensions', '', { name: 'spo-app-list', custom: true }, TreeItemCollapsibleState.Collapsed, undefined, undefined, 'sp-app-catalog-tenant-wide-extensions', undefined,
+        async () => {
+          const tenantWideExtensions = await CliActions.getTenantWideExtensions(tenantAppCatalogUrl);
+          const tenantWideExtensionsList: ActionTreeItem[] = [];
 
-            if (tenantWideExtensions && tenantWideExtensions.length > 0) {
-              tenantWideExtensions.forEach((extension) => {
-                tenantWideExtensionsList.push(
-                  new ActionTreeItem(extension.Title, '', { name: 'spo-app', custom: true }, TreeItemCollapsibleState.None, 'vscode.open', Uri.parse(extension.Url), 'sp-app-catalog-tenant-wide-extensions-url')
-                );
-              });
-            } else {
-              tenantWideExtensionsList.push(new ActionTreeItem('No extension found', ''));
-            }
-
-            return tenantWideExtensionsList;
+          if (tenantWideExtensions && tenantWideExtensions.length > 0) {
+            tenantWideExtensions.forEach((extension) => {
+              tenantWideExtensionsList.push(
+                new ActionTreeItem(extension.Title, '', { name: 'spo-app', custom: true }, TreeItemCollapsibleState.None, 'vscode.open', Uri.parse(extension.Url), 'sp-app-catalog-tenant-wide-extensions-url')
+              );
+            });
+          } else {
+            tenantWideExtensionsList.push(new ActionTreeItem('No extension found', ''));
           }
-        );
 
-        catalogItems.push(tenantWideExtensionsNode);
+          return tenantWideExtensionsList;
+        }
+      );
+
+      catalogItems.push(tenantWideExtensionsNode);
+
+      const showTenantAppCatalogApps: boolean = getExtensionSettings<boolean>('showTenantWideExtensions', true);
+      let showExpandTreeIcon: TreeItemCollapsibleState;
+      if (showTenantAppCatalogApps === true) {
+        showExpandTreeIcon = TreeItemCollapsibleState.Collapsed;
+      } else {
+        showExpandTreeIcon = TreeItemCollapsibleState.None;
       }
 
-      const tenantAppCatalogNode = new ActionTreeItem(tenantAppCatalogUrl.replace(origin, '...'), '', { name: 'globe', custom: false }, TreeItemCollapsibleState.Collapsed, 'vscode.open', `${Uri.parse(tenantAppCatalogUrl)}/AppCatalog`, 'sp-app-catalog-url', undefined,
+      const tenantAppCatalogNode = new ActionTreeItem(tenantAppCatalogUrl.replace(origin, '...'), '', { name: 'globe', custom: false }, showExpandTreeIcon, 'vscode.open', `${Uri.parse(tenantAppCatalogUrl)}/AppCatalog`, 'sp-app-catalog-url', undefined,
         async () => {
           const tenantAppCatalogApps = await CliActions.getAppCatalogApps();
           const tenantAppCatalogAppsList: ActionTreeItem[] = [];

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -192,8 +192,8 @@ export class CommandPanel {
 
       catalogItems.push(tenantWideExtensionsNode);
 
-      const showTenantAppCatalogApps: boolean = getExtensionSettings<boolean>('showTenantWideExtensions', true);
-      const showExpandTreeIcon = showTenantAppCatalogApps  ?  TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
+      const showTenantAppCatalogApps: boolean = getExtensionSettings<boolean>('showAppsInAppCatalogs', true);
+      const showExpandTreeIcon = showTenantAppCatalogApps ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
 
       const tenantAppCatalogNode = new ActionTreeItem(tenantAppCatalogUrl.replace(origin, '...'), '', { name: 'globe', custom: false }, showExpandTreeIcon, 'vscode.open', `${Uri.parse(tenantAppCatalogUrl)}/AppCatalog`, 'sp-app-catalog-url', undefined,
         async () => {
@@ -237,7 +237,7 @@ export class CommandPanel {
       for (let i = 1; i < appCatalogUrls.length; i++) {
         const siteAppCatalogUrl = appCatalogUrls[i];
 
-        const siteAppCatalogNode = new ActionTreeItem(siteAppCatalogUrl.replace(origin, '...'), '', { name: 'globe', custom: false }, TreeItemCollapsibleState.Collapsed, 'vscode.open', `${Uri.parse(siteAppCatalogUrl)}/AppCatalog`, 'sp-app-catalog-url', undefined,
+        const siteAppCatalogNode = new ActionTreeItem(siteAppCatalogUrl.replace(origin, '...'), '', { name: 'globe', custom: false }, showExpandTreeIcon, 'vscode.open', `${Uri.parse(siteAppCatalogUrl)}/AppCatalog`, 'sp-app-catalog-url', undefined,
           async () => {
             const siteAppCatalogApps = await CliActions.getAppCatalogApps(siteAppCatalogUrl);
             const siteAppCatalogAppsList: ActionTreeItem[] = [];

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -193,12 +193,7 @@ export class CommandPanel {
       catalogItems.push(tenantWideExtensionsNode);
 
       const showTenantAppCatalogApps: boolean = getExtensionSettings<boolean>('showTenantWideExtensions', true);
-      let showExpandTreeIcon: TreeItemCollapsibleState;
-      if (showTenantAppCatalogApps === true) {
-        showExpandTreeIcon = TreeItemCollapsibleState.Collapsed;
-      } else {
-        showExpandTreeIcon = TreeItemCollapsibleState.None;
-      }
+      const showExpandTreeIcon = showTenantAppCatalogApps  ?  TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
 
       const tenantAppCatalogNode = new ActionTreeItem(tenantAppCatalogUrl.replace(origin, '...'), '', { name: 'globe', custom: false }, showExpandTreeIcon, 'vscode.open', `${Uri.parse(tenantAppCatalogUrl)}/AppCatalog`, 'sp-app-catalog-url', undefined,
         async () => {


### PR DESCRIPTION
## 🎯 Aim

This PR refactors the tenant wide extensions logic to control the display of the app catalogs and the expansion of those if the setting is enabled

## 📷 Result

![vscode-viva-itemid-325-a](https://github.com/user-attachments/assets/9206405e-2031-40bf-8804-a06d51b7b9aa)
![vscode-viva-itemid-325-b](https://github.com/user-attachments/assets/0f927423-ebce-4852-9bf7-c832b89ac97e)
![vscode-viva-itemid-325-c](https://github.com/user-attachments/assets/27995725-67fc-4e6d-83af-e82c120aa7ff)
![vscode-viva-itemid-325-d](https://github.com/user-attachments/assets/e7ef9fae-a856-4b61-aab5-5bbf0d2e7c8a)

## ✅ What was done

> clarify what was done and what still needs to be finished ex. [Remove this line]

- [X] Updated setting title and description
- [X] Removed default show/hide for tenant extensions
- [X] Added show hide for appcatalogs and deployed apps including the toggle icon

## 🔗 Related issue

Closes: #325 