### PR TITLE
Add tenant app catalog & add/remove site app catalog. Closes #360

### DIFF
--- a/package.json
+++ b/package.json
@@ -839,7 +839,7 @@
 				"command": "spfx-toolkit.removeSiteAppCatalog",
 				"title": "Remove Site App Catalog",
 				"category": "SharePoint Framework Toolkit",
-				"icon": "$(remove)"
+				"icon": "$(trash)"
 			}
 		],
 		"menus": {

--- a/package.json
+++ b/package.json
@@ -822,6 +822,24 @@
 				"title": "Deploy project assets to Azure Storage",
 				"category": "SPFx Toolkit",
 				"icon": "$(cloud-upload)"
+			},
+			{
+				"command": "spfx-toolkit.addTenantAppCatalog",
+				"title": "Add Tenant App Catalog",
+				"category": "SharePoint Framework Toolkit",
+				"icon": "$(add)"
+			},
+			{
+				"command": "spfx-toolkit.addSiteAppCatalog",
+				"title": "Add Site App Catalog",
+				"category": "SharePoint Framework Toolkit",
+				"icon": "$(add)"
+			},
+			{
+				"command": "spfx-toolkit.removeSiteAppCatalog",
+				"title": "Remove Site App Catalog",
+				"category": "SharePoint Framework Toolkit",
+				"icon": "$(remove)"
 			}
 		],
 		"menus": {
@@ -906,6 +924,21 @@
 					"submenu": "spfx-toolkit.showMoreActions",
 					"when": "view == pnp-view-environment && viewItem == pnp.etv.hasAppCatalogApp",
 					"group": "inline@2"
+				},
+				{
+					"command": "spfx-toolkit.addTenantAppCatalog",
+					"when": "view == pnp-view-environment && viewItem == pnp.etv.hasNoAppCatalog",
+					"group": "inline"
+				},
+				{
+					"command": "spfx-toolkit.addSiteAppCatalog",
+					"when": "viewItem == sp-app-catalog-root",
+					"group": "inline"
+				},
+				{
+					"command": "spfx-toolkit.removeSiteAppCatalog",
+					"when": "viewItem == sp-app-catalog-url",
+					"group": "inline"
 				}
 			],
 			"spfx-toolkit.showMoreActions": [

--- a/src/constants/Commands.ts
+++ b/src/constants/Commands.ts
@@ -94,6 +94,11 @@ export const Commands = {
   uninstallAppCatalogApp: `${EXTENSION_NAME}.uninstallAppCatalogApp`,
   showMoreActions: `${EXTENSION_NAME}.showMoreActions`,
 
+  // App Catalog actions
+  addTenantAppCatalog: `${EXTENSION_NAME}.addTenantAppCatalog`,
+  addSiteAppCatalog: `${EXTENSION_NAME}.addSiteAppCatalog`,
+  removeSiteAppCatalog: `${EXTENSION_NAME}.removeSiteAppCatalog`,
+
   // Set form customizer
   setFormCustomizer: `${EXTENSION_NAME}.setFormCustomizer`
 };

--- a/src/constants/ContextKeys.ts
+++ b/src/constants/ContextKeys.ts
@@ -3,6 +3,7 @@ export const ContextKeys = {
   isSPFxProject: 'pnp.project.isSPFxProject',
   isLoggedIn: 'pnp.project.isLoggedIn',
   hasAppCatalog: 'pnp.project.hasAppCatalog',
+  hasNoAppCatalog: 'pnp.project.hasNoAppCatalog',
   hasAppCatalogApp: 'pnp.etv.hasAppCatalogApp',
   deployApp: 'pnp.etv.app.deploy',
   retractApp: 'pnp.etv.app.retract',

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -251,32 +251,17 @@ export class CommandPanel {
       for (let i = 1; i < appCatalogUrls.length; i++) {
         const siteAppCatalogUrl = appCatalogUrls[i];
 
-        const siteAppCatalogNode = new ActionTreeItem(
-          siteAppCatalogUrl.replace(origin, '...'),
-          '',
-          { name: 'globe', custom: false },
-          showExpandTreeIcon,
-          'vscode.open',
-          `${Uri.parse(siteAppCatalogUrl)}/AppCatalog`,
-          'sp-app-catalog-url',
-          undefined,
+        const siteAppCatalogNode = new ActionTreeItem(siteAppCatalogUrl.replace(origin, '...'), '', { name: 'globe', custom: false }, showExpandTreeIcon, 'vscode.open', `${Uri.parse(siteAppCatalogUrl)}/AppCatalog`, 'sp-app-catalog-url', undefined,
           async () => {
             const siteAppCatalogApps = await CliActions.getAppCatalogApps(siteAppCatalogUrl);
             const siteAppCatalogAppsList: ActionTreeItem[] = [];
-        
+
             if (siteAppCatalogApps && siteAppCatalogApps.length > 0) {
               siteAppCatalogApps.forEach((app) => {
                 const appStoreUrl = `${siteAppCatalogUrl}/_layouts/15/appStore.aspx/appDetail/${app.ID}?sorting=1&from=0&catalog=3`;
-        
+
                 siteAppCatalogAppsList.push(
-                  new ActionTreeItem(
-                    app.Title,
-                    '',
-                    { name: 'package', custom: false },
-                    undefined,
-                    'vscode.open',
-                    Uri.parse(appStoreUrl),
-                    ContextKeys.hasAppCatalogApp,
+                  new ActionTreeItem(app.Title, '', { name: 'package', custom: false }, undefined, 'vscode.open', Uri.parse(appStoreUrl), ContextKeys.hasAppCatalogApp,
                     [
                       new ActionTreeItem('Deploy', '', undefined, undefined, Commands.deployAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, app.Deployed], ContextKeys.deployApp),
                       new ActionTreeItem('Retract', '', undefined, undefined, Commands.retractAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, app.Deployed], ContextKeys.retractApp),
@@ -293,7 +278,7 @@ export class CommandPanel {
             } else {
               siteAppCatalogAppsList.push(new ActionTreeItem('No app found', ''));
             }
-        
+
             return siteAppCatalogAppsList;
           }
         );

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -166,7 +166,17 @@ export class CommandPanel {
     const environmentCommands: ActionTreeItem[] = [];
 
     if (!appCatalogUrls) {
-      environmentCommands.push(new ActionTreeItem('No app catalog found', ''));
+      environmentCommands.push(
+        new ActionTreeItem(
+          'Create an app catalog',
+          '',
+          { name: 'add', custom: false },
+          undefined,
+          Commands.addTenantAppCatalog,
+          ContextKeys.hasAppCatalogApp,
+          'sp-add-tenant-app-catalog'
+        )
+      );
     } else {
       const tenantAppCatalogUrl = appCatalogUrls[0];
       const origin = new URL(tenantAppCatalogUrl).origin;
@@ -199,7 +209,7 @@ export class CommandPanel {
       const showTenantAppCatalogApps: boolean = getExtensionSettings<boolean>('showAppsInAppCatalogs', true);
       const showExpandTreeIcon = showTenantAppCatalogApps ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
 
-      const tenantAppCatalogNode = new ActionTreeItem(tenantAppCatalogUrl.replace(origin, '...'), '', { name: 'globe', custom: false }, showExpandTreeIcon, 'vscode.open', `${Uri.parse(tenantAppCatalogUrl)}/AppCatalog`, 'sp-app-catalog-url', undefined,
+      const tenantAppCatalogNode = new ActionTreeItem(tenantAppCatalogUrl.replace(origin, '...'), '', { name: 'globe', custom: false }, showExpandTreeIcon, 'vscode.open', `${Uri.parse(tenantAppCatalogUrl)}/AppCatalog`, 'sp-tenant-app-catalog-url', undefined,
         async () => {
           const tenantAppCatalogApps = await CliActions.getAppCatalogApps();
           const tenantAppCatalogAppsList: ActionTreeItem[] = [];
@@ -241,17 +251,32 @@ export class CommandPanel {
       for (let i = 1; i < appCatalogUrls.length; i++) {
         const siteAppCatalogUrl = appCatalogUrls[i];
 
-        const siteAppCatalogNode = new ActionTreeItem(siteAppCatalogUrl.replace(origin, '...'), '', { name: 'globe', custom: false }, showExpandTreeIcon, 'vscode.open', `${Uri.parse(siteAppCatalogUrl)}/AppCatalog`, 'sp-app-catalog-url', undefined,
+        const siteAppCatalogNode = new ActionTreeItem(
+          siteAppCatalogUrl.replace(origin, '...'),
+          '',
+          { name: 'globe', custom: false },
+          showExpandTreeIcon,
+          'vscode.open',
+          `${Uri.parse(siteAppCatalogUrl)}/AppCatalog`,
+          'sp-app-catalog-url',
+          undefined,
           async () => {
             const siteAppCatalogApps = await CliActions.getAppCatalogApps(siteAppCatalogUrl);
             const siteAppCatalogAppsList: ActionTreeItem[] = [];
-
+        
             if (siteAppCatalogApps && siteAppCatalogApps.length > 0) {
               siteAppCatalogApps.forEach((app) => {
                 const appStoreUrl = `${siteAppCatalogUrl}/_layouts/15/appStore.aspx/appDetail/${app.ID}?sorting=1&from=0&catalog=3`;
-
+        
                 siteAppCatalogAppsList.push(
-                  new ActionTreeItem(app.Title, '', { name: 'package', custom: false }, undefined, 'vscode.open', Uri.parse(appStoreUrl), ContextKeys.hasAppCatalogApp,
+                  new ActionTreeItem(
+                    app.Title,
+                    '',
+                    { name: 'package', custom: false },
+                    undefined,
+                    'vscode.open',
+                    Uri.parse(appStoreUrl),
+                    ContextKeys.hasAppCatalogApp,
                     [
                       new ActionTreeItem('Deploy', '', undefined, undefined, Commands.deployAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, app.Deployed], ContextKeys.deployApp),
                       new ActionTreeItem('Retract', '', undefined, undefined, Commands.retractAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, app.Deployed], ContextKeys.retractApp),
@@ -268,7 +293,7 @@ export class CommandPanel {
             } else {
               siteAppCatalogAppsList.push(new ActionTreeItem('No app found', ''));
             }
-
+        
             return siteAppCatalogAppsList;
           }
         );
@@ -278,7 +303,7 @@ export class CommandPanel {
 
       if (siteAppCatalogActionItems.length > 0) {
         environmentCommands.push(
-          new ActionTreeItem('Site App Catalogs', '', { name: 'spo-logo', custom: true }, TreeItemCollapsibleState.Collapsed, undefined, undefined, undefined, siteAppCatalogActionItems)
+          new ActionTreeItem('Site App Catalogs', '', { name: 'spo-logo', custom: true }, TreeItemCollapsibleState.Collapsed, Commands.addSiteAppCatalog , undefined, "sp-app-catalog-root", siteAppCatalogActionItems)
         );
       }
     }

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -166,17 +166,7 @@ export class CommandPanel {
     const environmentCommands: ActionTreeItem[] = [];
 
     if (!appCatalogUrls) {
-      environmentCommands.push(
-        new ActionTreeItem(
-          'Create an app catalog',
-          '',
-          { name: 'add', custom: false },
-          undefined,
-          Commands.addTenantAppCatalog,
-          ContextKeys.hasAppCatalogApp,
-          'sp-add-tenant-app-catalog'
-        )
-      );
+      environmentCommands.push(new ActionTreeItem('Create an app catalog', '', { name: 'add', custom: false }, undefined, Commands.addTenantAppCatalog, ContextKeys.hasAppCatalogApp, 'sp-add-tenant-app-catalog'));
     } else {
       const tenantAppCatalogUrl = appCatalogUrls[0];
       const origin = new URL(tenantAppCatalogUrl).origin;
@@ -286,11 +276,13 @@ export class CommandPanel {
         siteAppCatalogActionItems.push(siteAppCatalogNode);
       }
 
-      if (siteAppCatalogActionItems.length > 0) {
-        environmentCommands.push(
-          new ActionTreeItem('Site App Catalogs', '', { name: 'spo-logo', custom: true }, TreeItemCollapsibleState.Collapsed, Commands.addSiteAppCatalog , undefined, "sp-app-catalog-root", siteAppCatalogActionItems)
-        );
+      if (siteAppCatalogActionItems.length === 0) {
+        siteAppCatalogActionItems.push(new ActionTreeItem('No site app catalog found', ''));
       }
+
+      environmentCommands.push(
+          new ActionTreeItem('Site App Catalogs', '', { name: 'spo-logo', custom: true }, TreeItemCollapsibleState.Collapsed, Commands.addSiteAppCatalog , undefined, 'sp-app-catalog-root', siteAppCatalogActionItems)
+        );
     }
 
     window.createTreeView('pnp-view-environment', { treeDataProvider: new ActionTreeDataProvider(environmentCommands), showCollapseAll: true });

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -816,7 +816,7 @@ export class CliActions {
 
     await window.withProgress({
       location: ProgressLocation.Notification,
-      title: `Creating Tenant App Catalog at ${appCatalogUrl}...`,
+      title: `Creating Tenant App Catalog at ${appCatalogUrl}... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
       cancellable: false,
     }, async () => {
       try {
@@ -879,7 +879,7 @@ export class CliActions {
 
       await window.withProgress({
         location: ProgressLocation.Notification,
-        title: `Creating site app catalog for ${siteUrl}...Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
+        title: `Creating site app catalog for ${siteUrl}... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
         cancellable: false,
       }, async () => {
         const commandOptions: any = { siteUrl };

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -661,6 +661,291 @@ export class CliActions {
     return result.stdout;
   }
 
+ /**
+   * Sets the form customizer for a content type on a list.
+   */
+  public static async setFormCustomizer() {
+    const relativeUrl = await window.showInputBox({
+      prompt: 'Enter the relative URL of the site',
+      ignoreFocusOut: true,
+      placeHolder: 'e.g., sites/sales or leave blank for root site',
+      validateInput: (input) => {
+        const trimmedInput = input.trim();
+
+        if (trimmedInput.startsWith('https://')) {
+          return 'Please provide a relative URL, not an absolute URL.';
+        }
+        if (trimmedInput.startsWith('/')) {
+          return 'Please provide a relative URL without a leading slash.';
+        }
+
+        return undefined;
+      }
+    });
+
+    if (relativeUrl === undefined) {
+      Notifications.warning('No site URL provided. Setting form customizer aborted.');
+      return;
+    }
+
+    const siteUrl = `${EnvironmentInformation.tenantUrl}/${relativeUrl.trim()}`;
+
+    const listTitle = await window.showInputBox({
+      prompt: 'Enter the list title',
+      ignoreFocusOut: true,
+      validateInput: (value) => value ? undefined : 'List title is required'
+    });
+
+    if (!listTitle) {
+      Notifications.warning('No list title provided. Setting form customizer aborted.');
+      return;
+    }
+
+    const contentType = await window.showInputBox({
+      prompt: 'Enter the Content Type name',
+      ignoreFocusOut: true,
+      validateInput: (value) => value ? undefined : 'Content Type name is required'
+    });
+
+    if (!contentType) {
+      Notifications.warning('No content type name provided. Setting form customizer aborted.');
+      return;
+    }
+
+    const editFormClientSideComponentId = await window.showInputBox({
+      prompt: 'Enter the Edit form customizer ID (leave empty to skip)',
+      ignoreFocusOut: true
+    });
+
+    const newFormClientSideComponentId = await window.showInputBox({
+      prompt: 'Enter the New form customizer ID (leave empty to skip)',
+      ignoreFocusOut: true
+    });
+
+    const displayFormClientSideComponentId = await window.showInputBox({
+      prompt: 'Enter the View form customizer ID (leave empty to skip)',
+      ignoreFocusOut: true
+    });
+
+    const commandOptions: any = {
+      webUrl: siteUrl,
+      listTitle: listTitle,
+      name: contentType
+    };
+
+    if (editFormClientSideComponentId) {
+      commandOptions.EditFormClientSideComponentId = editFormClientSideComponentId;
+    }
+
+    if (newFormClientSideComponentId) {
+      commandOptions.NewFormClientSideComponentId = newFormClientSideComponentId;
+    }
+
+    if (displayFormClientSideComponentId) {
+      commandOptions.DisplayFormClientSideComponentId = displayFormClientSideComponentId;
+    }
+
+    await window.withProgress({
+      location: ProgressLocation.Notification,
+      title: `Setting form customizer... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
+      cancellable: true
+    }, async (progress: Progress<{ message?: string; increment?: number }>) => {
+      try {
+        const result = await CliExecuter.execute('spo contenttype set', 'json', commandOptions);
+        if (result.stderr) {
+          Notifications.error(result.stderr);
+        } else {
+          Notifications.info('Form customizer set successfully.');
+        }
+      } catch (e: any) {
+        const message = e?.error?.message;
+        Notifications.error(message);
+      }
+    });
+  }
+
+/**
+   * Adds a Tenant App Catalog.
+   * The URL is fixed to "https://domain.sharepoint.com/sites/appcatalog".
+   * Prompts the user for the owner and timeZone.
+   */
+  public static async addTenantAppCatalog() {
+    const tenantUrl = EnvironmentInformation.tenantUrl;
+    if (!tenantUrl) {
+      Notifications.error('Tenant URL not found. Please ensure you are logged in.');
+      return;
+    }
+
+    const appCatalogUrl = `${tenantUrl}/sites/appcatalog`;
+
+    const owner: string | undefined = await window.showInputBox({
+      prompt: 'Enter the email address of the tenant admin (owner)',
+      ignoreFocusOut: true,
+      value: EnvironmentInformation.account || '',
+      validateInput: (value) => value ? undefined : 'Owner email is required',
+    });
+    if (!owner) {
+      Notifications.error('Owner email is required to create a Tenant App Catalog.');
+      return;
+    }
+
+    const timeZoneInput = await window.showInputBox({
+      prompt: 'Enter the time zone as an integer (e.g., 4 for UTC+4). Refer to the guidelines: https://msdn.microsoft.com/library/microsoft.sharepoint.spregionalsettings.timezones.aspx',
+      ignoreFocusOut: true,
+      validateInput: (value) => {
+        const parsed = parseInt(value, 10);
+        return isNaN(parsed) ? 'Time zone must be an integer' : undefined;
+      },
+    });
+
+    if (!timeZoneInput) {
+      Notifications.error('Time zone is required to create a Tenant App Catalog.');
+      return;
+    }
+
+    const timeZone = parseInt(timeZoneInput, 10);
+
+    const confirmation = await window.showQuickPick(['Yes', 'No'], {
+      placeHolder: `Are you sure you want to create a Tenant App Catalog at '${appCatalogUrl}' with owner '${owner}' and time zone '${timeZone}'?`,
+      ignoreFocusOut: true,
+    });
+
+    if (confirmation !== 'Yes') {
+      return;
+    }
+
+    await window.withProgress({
+      location: ProgressLocation.Notification,
+      title: `Creating Tenant App Catalog at ${appCatalogUrl}...`,
+      cancellable: false,
+    }, async () => {
+      try {
+        const commandOptions: any = {
+          url: appCatalogUrl,
+          owner,
+          timeZone,
+        };
+        const result = await CliExecuter.execute('spo tenant appcatalog add', 'json', commandOptions);
+
+        if (result.stderr) {
+          Notifications.error(result.stderr);
+        } else {
+          Notifications.info(`Tenant App Catalog created successfully at '${appCatalogUrl}'.`);
+          await commands.executeCommand('spfx-toolkit.refreshAppCatalogTreeView');
+        }
+      } catch (e: any) {
+        const message = e?.error?.message || 'An unexpected error occurred.';
+        Notifications.error(message);
+      }
+    });
+  }
+
+  /**
+   * Adds a Site Collection App Catalog.
+   * Prompts for the url.
+   */
+  public static async addSiteAppCatalog() {
+    try {
+      const relativeUrl = await window.showInputBox({
+        prompt: 'Enter the relative URL of the site where you want to create the site app catalog',
+        ignoreFocusOut: true,
+        placeHolder: 'e.g., sites/sales or leave blank for root site',
+        validateInput: (input) => {
+          const trimmedInput = input.trim();
+          if (trimmedInput.startsWith('https://')) {
+            return 'Please provide a relative URL, not an absolute URL.';
+          }
+          if (trimmedInput.startsWith('/')) {
+            return 'Please provide a relative URL without a leading slash.';
+          }
+          return undefined;
+        }});
+
+      if (!relativeUrl) {
+        Notifications.warning('No site URL provided. Operation aborted.');
+        return;
+      }
+
+      const siteUrl = `${EnvironmentInformation.tenantUrl}/${relativeUrl.trim()}`;
+
+      const confirmation = await window.showQuickPick(['Yes', 'No'], {
+        placeHolder: `Are you sure you want to create a site app catalog for '${relativeUrl}'?`,
+        ignoreFocusOut: true,
+      });
+
+      if (confirmation !== 'Yes') {
+        return;
+      }
+
+      await window.withProgress({
+        location: ProgressLocation.Notification,
+        title: `Creating site app catalog for ${siteUrl}...Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
+        cancellable: false,
+      }, async () => {
+        const commandOptions: any = { siteUrl };
+        const result = await CliExecuter.execute('spo site appcatalog add', 'json', commandOptions);
+
+        if (result.stderr) {
+          Notifications.error(result.stderr);
+        } else {
+          Notifications.info(`Site app catalog created successfully for '${siteUrl}'.`);
+          await commands.executeCommand('spfx-toolkit.refreshAppCatalogTreeView');
+        }
+      });
+    } catch (e: any) {
+      const message = e?.error?.message || 'An unexpected error occurred.';
+      Notifications.error(message);
+    }
+  }
+
+  /**
+   * Removes a Site Collection App Catalog.
+   */
+  public static async removeSiteAppCatalog(node: ActionTreeItem) {
+    try {
+      let [appCatalogUrl] = node.command?.arguments || [];
+
+      if (!appCatalogUrl) {
+        Notifications.error('Failed to retrieve app catalog details for removal.');
+        return;
+      }
+
+      appCatalogUrl = appCatalogUrl.replace('/AppCatalog', '');
+
+      const shouldRemove = await window.showQuickPick(['Yes', 'No'], {
+        title: `Are you sure you want to remove the site app catalog from site '${appCatalogUrl}'?`,
+        ignoreFocusOut: true,
+        canPickMany: false
+      });
+
+      const shouldRemoveAnswer = shouldRemove === 'Yes';
+
+      if (!shouldRemoveAnswer) {
+        return;
+      }
+
+      const commandOptions: any = {
+        siteUrl: appCatalogUrl?.trim(),
+        force: true
+      };
+
+      await window.withProgress({
+        location: ProgressLocation.Notification,
+        title: `Removing site app catalog from ${appCatalogUrl}... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
+        cancellable: false,
+      }, async () => {
+        await CliExecuter.execute('spo site appcatalog remove', 'json', commandOptions);
+      });
+
+      Notifications.info(`App catalog '${appCatalogUrl}' has been successfully removed. Note: The App Catalog library will remain in the site, but it will be in a disabled state.`);
+
+      await commands.executeCommand('spfx-toolkit.refreshAppCatalogTreeView');
+    } catch (e: any) {
+      const message = e?.error?.message;
+      Notifications.error(message);
+    }
+  }
+
   /**
    * Upgrades the project by generating the upgrade steps and displaying them in a Markdown preview.
    * @private
@@ -1026,290 +1311,6 @@ export class CliActions {
       }, 500);
     } else {
       Notifications.error(`${fileName}.tour file not found in path ${path.join(wsFolder.uri.fsPath, '.tours')}. Cannot start Code Tour.`);
-    }
-  }
-
-  /**
-   * Sets the form customizer for a content type on a list.
-   */
-  public static async setFormCustomizer() {
-    const relativeUrl = await window.showInputBox({
-      prompt: 'Enter the relative URL of the site',
-      ignoreFocusOut: true,
-      placeHolder: 'e.g., sites/sales or leave blank for root site',
-      validateInput: (input) => {
-        const trimmedInput = input.trim();
-
-        if (trimmedInput.startsWith('https://')) {
-          return 'Please provide a relative URL, not an absolute URL.';
-        }
-        if (trimmedInput.startsWith('/')) {
-          return 'Please provide a relative URL without a leading slash.';
-        }
-
-        return undefined;
-      }
-    });
-
-    if (relativeUrl === undefined) {
-      Notifications.warning('No site URL provided. Setting form customizer aborted.');
-      return;
-    }
-
-    const siteUrl = `${EnvironmentInformation.tenantUrl}/${relativeUrl.trim()}`;
-
-    const listTitle = await window.showInputBox({
-      prompt: 'Enter the list title',
-      ignoreFocusOut: true,
-      validateInput: (value) => value ? undefined : 'List title is required'
-    });
-
-    if (!listTitle) {
-      Notifications.warning('No list title provided. Setting form customizer aborted.');
-      return;
-    }
-
-    const contentType = await window.showInputBox({
-      prompt: 'Enter the Content Type name',
-      ignoreFocusOut: true,
-      validateInput: (value) => value ? undefined : 'Content Type name is required'
-    });
-
-    if (!contentType) {
-      Notifications.warning('No content type name provided. Setting form customizer aborted.');
-      return;
-    }
-
-    const editFormClientSideComponentId = await window.showInputBox({
-      prompt: 'Enter the Edit form customizer ID (leave empty to skip)',
-      ignoreFocusOut: true
-    });
-
-    const newFormClientSideComponentId = await window.showInputBox({
-      prompt: 'Enter the New form customizer ID (leave empty to skip)',
-      ignoreFocusOut: true
-    });
-
-    const displayFormClientSideComponentId = await window.showInputBox({
-      prompt: 'Enter the View form customizer ID (leave empty to skip)',
-      ignoreFocusOut: true
-    });
-
-    const commandOptions: any = {
-      webUrl: siteUrl,
-      listTitle: listTitle,
-      name: contentType
-    };
-
-    if (editFormClientSideComponentId) {
-      commandOptions.EditFormClientSideComponentId = editFormClientSideComponentId;
-    }
-
-    if (newFormClientSideComponentId) {
-      commandOptions.NewFormClientSideComponentId = newFormClientSideComponentId;
-    }
-
-    if (displayFormClientSideComponentId) {
-      commandOptions.DisplayFormClientSideComponentId = displayFormClientSideComponentId;
-    }
-
-    await window.withProgress({
-      location: ProgressLocation.Notification,
-      title: `Setting form customizer... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
-      cancellable: true
-    }, async (progress: Progress<{ message?: string; increment?: number }>) => {
-      try {
-        const result = await CliExecuter.execute('spo contenttype set', 'json', commandOptions);
-        if (result.stderr) {
-          Notifications.error(result.stderr);
-        } else {
-          Notifications.info('Form customizer set successfully.');
-        }
-      } catch (e: any) {
-        const message = e?.error?.message;
-        Notifications.error(message);
-      }
-    });
-  }
-
-  /**
-   * Adds a Tenant App Catalog.
-   * The URL is fixed to "https://domain.sharepoint.com/sites/appcatalog".
-   * Prompts the user for the owner and timeZone.
-   */
-  public static async addTenantAppCatalog() {
-    const tenantUrl = EnvironmentInformation.tenantUrl;
-    if (!tenantUrl) {
-      Notifications.error('Tenant URL not found. Please ensure you are logged in.');
-      return;
-    }
-
-    const appCatalogUrl = `${tenantUrl}/sites/appcatalog`;
-
-    const owner: string | undefined = await window.showInputBox({
-      prompt: 'Enter the email address of the tenant admin (owner)',
-      ignoreFocusOut: true,
-      validateInput: (value) => value ? undefined : EnvironmentInformation.account ? undefined : 'Owner email is required',
-    });
-    if (!owner) {
-      Notifications.error('Owner email is required to create a Tenant App Catalog.');
-      return;
-    }
-
-    const timeZoneInput = await window.showInputBox({
-      prompt: 'Enter the time zone as an integer (e.g., 4 for UTC+4). Refer to the guidelines: https://msdn.microsoft.com/library/microsoft.sharepoint.spregionalsettings.timezones.aspx',
-      ignoreFocusOut: true,
-      validateInput: (value) => {
-        const parsed = parseInt(value, 10);
-        return isNaN(parsed) ? 'Time zone must be an integer' : undefined;
-      },
-    });
-
-    if (!timeZoneInput) {
-      Notifications.error('Time zone is required to create a Tenant App Catalog.');
-      return;
-    }
-
-    const timeZone = parseInt(timeZoneInput, 10);
-
-    const confirmation = await window.showQuickPick(['Yes', 'No'], {
-      placeHolder: `Are you sure you want to create a Tenant App Catalog at '${appCatalogUrl}' with owner '${owner}' and time zone '${timeZone}'?`,
-      ignoreFocusOut: true,
-    });
-
-    if (confirmation !== 'Yes') {
-      return;
-    }
-
-    await window.withProgress({
-      location: ProgressLocation.Notification,
-      title: `Creating Tenant App Catalog at ${appCatalogUrl}...`,
-      cancellable: false,
-    }, async () => {
-      try {
-        const commandOptions: any = {
-          url: appCatalogUrl,
-          owner,
-          timeZone,
-        };
-        const result = await CliExecuter.execute('spo tenant appcatalog add', 'json', commandOptions);
-
-        if (result.stderr) {
-          Notifications.error(result.stderr);
-        } else {
-          Notifications.info(`Tenant App Catalog created successfully at '${appCatalogUrl}'.`);
-          await commands.executeCommand('spfx-toolkit.refreshAppCatalogTreeView');
-        }
-      } catch (e: any) {
-        const message = e?.error?.message || 'An unexpected error occurred.';
-        Notifications.error(message);
-      }
-    });
-  }
-
-  /**
-   * Adds a Site Collection App Catalog.
-   * Prompts for the url.
-   */
-  public static async addSiteAppCatalog() {
-    try {
-      const relativeUrl = await window.showInputBox({
-        prompt: 'Enter the relative URL of the site where you want to create the site app catalog',
-        ignoreFocusOut: true,
-        placeHolder: 'e.g., sites/sales or leave blank for root site',
-        validateInput: (input) => {
-          const trimmedInput = input.trim();
-          if (trimmedInput.startsWith('https://')) {
-            return 'Please provide a relative URL, not an absolute URL.';
-          }
-          if (trimmedInput.startsWith('/')) {
-            return 'Please provide a relative URL without a leading slash.';
-          }
-          return undefined;
-        }});
-
-      if (!relativeUrl) {
-        Notifications.warning('No site URL provided. Operation aborted.');
-        return;
-      }
-
-      const siteUrl = `${EnvironmentInformation.tenantUrl}/${relativeUrl.trim()}`;
-
-      const confirmation = await window.showQuickPick(['Yes', 'No'], {
-        placeHolder: `Are you sure you want to create a site app catalog for '${relativeUrl}'?`,
-        ignoreFocusOut: true,
-      });
-
-      if (confirmation !== 'Yes') {
-        return;
-      }
-
-      await window.withProgress({
-        location: ProgressLocation.Notification,
-        title: `Creating site app catalog for ${siteUrl}...Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
-        cancellable: false,
-      }, async () => {
-        const commandOptions: any = { siteUrl };
-        const result = await CliExecuter.execute('spo site appcatalog add', 'json', commandOptions);
-
-        if (result.stderr) {
-          Notifications.error(result.stderr);
-        } else {
-          Notifications.info(`Site app catalog created successfully for '${siteUrl}'.`);
-          await commands.executeCommand('spfx-toolkit.refreshAppCatalogTreeView');
-        }
-      });
-    } catch (e: any) {
-      const message = e?.error?.message || 'An unexpected error occurred.';
-      Notifications.error(message);
-    }
-  }
-
-  /**
-   * Removes a Site Collection App Catalog.
-   */
-  public static async removeSiteAppCatalog(node: ActionTreeItem) {
-    try {
-      let [appCatalogUrl] = node.command?.arguments || [];
-
-      if (!appCatalogUrl) {
-        Notifications.error('Failed to retrieve app catalog details for removal.');
-        return;
-      }
-
-      appCatalogUrl = appCatalogUrl.replace('/AppCatalog', '');
-
-      const shouldRemove = await window.showQuickPick(['Yes', 'No'], {
-        title: `Are you sure you want to remove the site app catalog from site '${appCatalogUrl}'?`,
-        ignoreFocusOut: true,
-        canPickMany: false
-      });
-
-      const shouldRemoveAnswer = shouldRemove === 'Yes';
-
-      if (!shouldRemoveAnswer) {
-        return;
-      }
-
-      const commandOptions: any = {
-        siteUrl: appCatalogUrl?.trim(),
-        force: true
-      };
-
-      await window.withProgress({
-        location: ProgressLocation.Notification,
-        title: `Removing site app catalog from ${appCatalogUrl}... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
-        cancellable: false,
-      }, async () => {
-        await CliExecuter.execute('spo site appcatalog remove', 'json', commandOptions);
-      });
-
-      Notifications.info(`App catalog '${appCatalogUrl}' has been successfully removed.`);
-
-      await commands.executeCommand('spfx-toolkit.refreshAppCatalogTreeView');
-    } catch (e: any) {
-      const message = e?.error?.message;
-      Notifications.error(message);
     }
   }
 }


### PR DESCRIPTION
Soooooo, i did a little oopsie woopsie and totally broke the other PR 😅 

## 🎯 Aim

This feature adds the possibility to add a tenant app catalog of it doesn't exist and the possibility to add or remove a site app catalog

## 📷 Result

![image](https://github.com/user-attachments/assets/18914ea4-f988-45f0-a93d-0085c4b10d88)

## ✅ What was done

> clarify what was done and what still needs to be finished ex. [Remove this line]

- [X] Adding feature to add a tenant app catalog - if none exist
- [X] Adding feature to add a site app catalog
- [X] Adding feature to remove a site app catalog
- [ ] A feature to choose from existing sites as dropdown when adding a site catalog - this would be a nice issue - currently i didn't succeed in this as i couldn't parse the looooong json getting back from the cli command sites list

## 🔗 Related issue

Closes: #360