### PR TITLE
Hides app management related context-menu actions from the command pa…

### DIFF
--- a/package.json
+++ b/package.json
@@ -803,6 +803,42 @@
 				{
 					"command": "spfx-toolkit.validateProject",
 					"when": "pnp.project.isSPFxProject"
+				},
+				{
+					"command": "spfx-toolkit.deployAppCatalogApp",
+					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.showMoreActions",
+					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.retractAppCatalogApp",
+					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.removeAppCatalogApp",
+					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.enableAppCatalogApp",
+					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.disableAppCatalogApp",
+					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.upgradeAppCatalogApp",
+					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.installAppCatalogApp",
+					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.uninstallAppCatalogApp",
+					"when": "false"
 				}
 			],
 			"view/title": [


### PR DESCRIPTION
## 🎯 Aim

> Hides app management related context-menu actions from the command palette.

## 📷 Result

> before 
![image](https://github.com/user-attachments/assets/d5b29b7f-c0cb-4e30-b2bf-92c03c0db2f0)

> After 
![image](https://github.com/user-attachments/assets/1b24f886-19c2-4bc7-a8a9-9b8437af248e)

## ✅ What was done

> clarify what was done and what still needs to be finished ex. [Remove this line]

- [X] Hide all app management related actions from the command palette.

## 🔗 Related issue

Closes: #423