### PR TITLE
💡Fix:474-Shorten command name in command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -563,7 +563,7 @@
 			"activitybar": [
 				{
 					"id": "pnp-view",
-					"title": "SharePoint Framework Toolkit",
+					"title": "SPFx Toolkit",
 					"icon": "assets/logo-light.svg"
 				}
 			]
@@ -572,7 +572,7 @@
 			"pnp-view": [
 				{
 					"id": "pnp-view-empty",
-					"name": "SharePoint Framework Toolkit",
+					"name": "SPFx Toolkit",
 					"when": "pnp.project.showWelcome"
 				},
 				{


### PR DESCRIPTION
## 🎯 Aim

To fix the issue #474, to shorten the command prefix from 'SharePoint Framework Toolkit' to 'SPFx Toolkit' for all actions.

## 📷 Result

Now all the commands in the command palette is adhering to 'SPFx Toolkit' as shown below. 

![image](https://github.com/user-attachments/assets/098fcfd3-6ae3-49be-9282-6fe92d3482a7)


## ✅ What was done

updated the view and activitybar container name & title to `SPFx Toolkit`  in `package.json` to make it consistent. 

- [] not done
- [X] done

## 🔗 Related issue
Closes: #474 