### PR TITLE
Fix-490-Align command icons for gulp tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -771,55 +771,55 @@
 				"command": "spfx-toolkit.bundleProject",
 				"title": "Bundle",
 				"category": "SPFx Toolkit",
-				"icon": "$(sync)"
+				"icon": "$(package)"
 			},
 			{
 				"command": "spfx-toolkit.packageProject",
 				"title": "Package",
 				"category": "SPFx Toolkit",
-				"icon": "$(sync)"
+				"icon": "$(zap)"
 			},
 			{
 				"command": "spfx-toolkit.publishProject",
 				"title": "Publish",
 				"category": "SPFx Toolkit",
-				"icon": "$(sync)"
+				"icon": "$(rocket)"
 			},
 			{
 				"command": "spfx-toolkit.serveProject",
 				"title": "Serve",
 				"category": "SPFx Toolkit",
-				"icon": "$(sync)"
+				"icon": "$(play-circle)"
 			},
 			{
 				"command": "spfx-toolkit.cleanProject",
 				"title": "Clean",
 				"category": "SPFx Toolkit",
-				"icon": "$(sync)"
+				"icon": "$(clear-all)"
 			},
 			{
 				"command": "spfx-toolkit.buildProject",
 				"title": "Build",
 				"category": "SPFx Toolkit",
-				"icon": "$(sync)"
+				"icon": "$(gear)"
 			},
 			{
 				"command": "spfx-toolkit.testProject",
 				"title": "Test",
 				"category": "SPFx Toolkit",
-				"icon": "$(sync)"
+				"icon": "$(beaker)"
 			},
 			{
 				"command": "spfx-toolkit.trustDevCert",
 				"title": "Trust self-signed developer certificate",
 				"category": "SPFx Toolkit",
-				"icon": "$(sync)"
+				"icon": "$(verified)"
 			},
 			{
 				"command": "spfx-toolkit.deployToAzureStorage",
 				"title": "Deploy project assets to Azure Storage",
 				"category": "SPFx Toolkit",
-				"icon": "$(sync)"
+				"icon": "$(cloud-upload)"
 			}
 		],
 		"menus": {

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -288,15 +288,15 @@ export class CommandPanel {
 
   private static taskTreeView() {
     const taskCommands: ActionTreeItem[] = [
-      new ActionTreeItem('Build project', '', { name: 'debug-start', custom: false }, undefined, Commands.buildProject),
-      new ActionTreeItem('Bundle project', '', { name: 'debug-start', custom: false }, undefined, Commands.bundleProject),
-      new ActionTreeItem('Clean project', '', { name: 'debug-start', custom: false }, undefined, Commands.cleanProject),
-      new ActionTreeItem('Deploy project assets to Azure Storage', '', { name: 'debug-start', custom: false }, undefined, Commands.deployToAzureStorage),
-      new ActionTreeItem('Package', '', { name: 'debug-start', custom: false }, undefined, Commands.packageProject),
-      new ActionTreeItem('Publish', '', { name: 'debug-start', custom: false }, undefined, Commands.publishProject),
-      new ActionTreeItem('Serve', '', { name: 'debug-start', custom: false }, undefined, Commands.serveProject),
-      new ActionTreeItem('Test', '', { name: 'debug-start', custom: false }, undefined, Commands.testProject),
-      new ActionTreeItem('Trust self-signed developer certificate', '', { name: 'debug-start', custom: false }, undefined, Commands.trustDevCert),
+      new ActionTreeItem('Build project', '', { name: 'gear', custom: false }, undefined, Commands.buildProject),
+      new ActionTreeItem('Bundle project', '', { name: 'package', custom: false }, undefined, Commands.bundleProject),
+      new ActionTreeItem('Clean project', '', { name: 'clear-all', custom: false }, undefined, Commands.cleanProject),
+      new ActionTreeItem('Deploy project assets to Azure Storage', '', { name: 'cloud-upload', custom: false }, undefined, Commands.deployToAzureStorage),
+      new ActionTreeItem('Package', '', { name: 'zap', custom: false }, undefined, Commands.packageProject),
+      new ActionTreeItem('Publish', '', { name: 'rocket', custom: false }, undefined, Commands.publishProject),
+      new ActionTreeItem('Serve', '', { name: 'play-circle', custom: false }, undefined, Commands.serveProject),
+      new ActionTreeItem('Test', '', { name: 'beaker', custom: false }, undefined, Commands.testProject),
+      new ActionTreeItem('Trust self-signed developer certificate', '', { name: 'verified', custom: false }, undefined, Commands.trustDevCert),
     ];
 
     window.registerTreeDataProvider('pnp-view-tasks', new ActionTreeDataProvider(taskCommands));


### PR DESCRIPTION
## 🎯 Aim

To align the command icons on both Tree view and the command palette

## 📷 Result
 Old Icons are as below, 

![image](https://github.com/user-attachments/assets/9526ff64-1f06-4542-a017-ed9e1832b77f)

New Icons are as below, 

![Icon-New](https://github.com/user-attachments/assets/9c072d30-d4a8-4f19-8801-591103f763c6)

Below are the details about the Icons

Gulp Task | Icon | Icon Label
-- | -- | --
Build Project | $(gear) | gear 
Bundle Project  | $(package) | package
Package Solution | $(zap) | zap
Publish Solution | $(rocket) | rocket
Clean Solution | $(clear-all) | clear-all
Test | $(beaker) | beaker 
Trust Dev Certificate | $(verified) | verified 
Deploy to Azure Storage | $(cloud-upload) | cloud-upload (deploy)

## ✅ What was done

Changed the Icons on both `CommandPanel.ts` and `package.json`

- [] not done
- [X] done

## 🔗 Related issue

Closes: #490 