### PR TITLE
fix(readme): fix broken image links for proper rendering

### DIFF
--- a/src/webview/view/components/gallery/DetailsView.tsx
+++ b/src/webview/view/components/gallery/DetailsView.tsx
@@ -29,6 +29,8 @@ export const DetailsView: React.FunctionComponent<IDetailsViewProps> = ({ }: Rea
       let data = await response.text();
       data = data.replace(/\]\(assets/g, `](${url}/assets`);
       data = data.replace(/\]\(\.\/assets/g, `](${url}/assets`);
+      data = data.replace(/\]\(images/g, `](${url}/images`);
+      data = data.replace(/\]\(\.\/images/g, `](${url}/images`);
       data = data.replace(/<img src="https:\/\/m365-visitor-stats\.azurewebsites\.net\/[^"]*" \/>/g, '');
       setDocs(data);
     };


### PR DESCRIPTION
## 🎯 Aim

Fix broken image links in the README by updating relative paths to use raw.githubusercontent.com, ensuring proper rendering across environments like SharePoint.

## 📷 Result

![image](https://github.com/user-attachments/assets/3035fd69-84b2-448d-84c5-06111eee60e6)

## ✅ What was done

- [x] Updated `README.md` to replace broken relative image paths
- [x] Added logic to handle `images/` path dynamically via script

## 🔗 Related issue

Closes: [#473](https://github.com/pnp/vscode-viva/issues/473)
