### PR TITLE
Bump Node.js version from 20 to 22 in workflow files

### DIFF
--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout SPFx Toolkit

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout vscode-viva

--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout vscode-viva

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout vscode-viva


### PR DESCRIPTION
## 🎯 Aim

Update the node version in all GitHub workflows to v22

## 📷 Result
N/A

## ✅ What was done

Updated the node version in all GitHub workflows to v22

- [X] done

## 🔗 Related issue

Closes: #[485](https://github.com/pnp/vscode-viva/issues/485)