### PR TITLE
Issue 435

### DIFF
--- a/package.json
+++ b/package.json
@@ -840,6 +840,30 @@
 				"title": "Remove Site App Catalog",
 				"category": "SPFx Toolkit",
 				"icon": "$(trash)"
+			},
+			{
+				"command": "spfx-toolkit.moreTenantWideExtensionActions",
+				"title": "...",
+				"category": "SPFx Toolkit",
+				"icon": "$(ellipsis)"
+			},
+			{
+				"command": "spfx-toolkit.removeTenantWideExtension",
+				"title": "Remove",
+				"category": "SPFx Toolkit",
+				"icon": "$(trash)"
+			},
+			{
+				"command": "spfx-toolkit.enableTenantWideExtension",
+				"title": "Enable",
+				"category": "SPFx Toolkit",
+				"icon": "$(check)"
+			},
+			{
+				"command": "spfx-toolkit.disableTenantWideExtension",
+				"title": "Disable",
+				"category": "SPFx Toolkit",
+				"icon": "$(circle-slash)"
 			}
 		],
 		"menus": {
@@ -895,6 +919,22 @@
 				{
 					"command": "spfx-toolkit.uninstallAppCatalogApp",
 					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.moreTenantWideExtensionActions",
+					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.removeTenantWideExtension",
+					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.enableTenantWideExtension",
+					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.disableTenantWideExtension",
+					"when": "false"
 				}
 			],
 			"view/title": [
@@ -939,6 +979,11 @@
 					"command": "spfx-toolkit.removeSiteAppCatalog",
 					"when": "viewItem == sp-app-catalog-url",
 					"group": "inline"
+				},
+				{
+					"submenu": "spfx-toolkit.moreTenantWideExtensionActions",
+					"when": "view == pnp-view-environment && viewItem == pnp.etv.hasTenantWideExtension",
+					"group": "inline@2"
 				}
 			],
 			"spfx-toolkit.showMoreActions": [
@@ -975,6 +1020,20 @@
 					"group": "actions.more@5"
 				}
 			],
+			"spfx-toolkit.moreTenantWideExtensionActions": [
+				{
+					"command": "spfx-toolkit.removeTenantWideExtension",
+					"group": "actions.more@1"
+				},
+				{
+					"command": "spfx-toolkit.enableTenantWideExtension",
+					"group": "actions.more@2"
+				},
+				{
+					"command": "spfx-toolkit.disableTenantWideExtension",
+					"group": "actions.more@3"
+				}
+			],
 			"explorer/context": [
 				{
 					"command": "spfx-toolkit.deployProject",
@@ -986,6 +1045,11 @@
 		"submenus": [
 			{
 				"id": "spfx-toolkit.showMoreActions",
+				"label": "More Actions...",
+				"icon": "$(ellipsis)"
+			},
+			{
+				"id": "spfx-toolkit.moreTenantWideExtensionActions",
 				"label": "More Actions...",
 				"icon": "$(ellipsis)"
 			}

--- a/src/constants/Commands.ts
+++ b/src/constants/Commands.ts
@@ -100,5 +100,10 @@ export const Commands = {
   removeSiteAppCatalog: `${EXTENSION_NAME}.removeSiteAppCatalog`,
 
   // Set form customizer
-  setFormCustomizer: `${EXTENSION_NAME}.setFormCustomizer`
+  setFormCustomizer: `${EXTENSION_NAME}.setFormCustomizer`,
+
+  // Tenant-wide extension actions
+  removeTenantWideExtension: `${EXTENSION_NAME}.removeTenantWideExtension`,
+  enableTenantWideExtension: `${EXTENSION_NAME}.enableTenantWideExtension`,
+  disableTenantWideExtension: `${EXTENSION_NAME}.disableTenantWideExtension`
 };

--- a/src/constants/ContextKeys.ts
+++ b/src/constants/ContextKeys.ts
@@ -12,5 +12,9 @@ export const ContextKeys = {
   disableApp: 'pnp.etv.app.disable',
   upgradeApp: 'pnp.etv.app.upgrade',
   installApp: 'pnp.etv.app.install',
-  uninstallApp: 'pnp.etv.app.uninstall'
+  uninstallApp: 'pnp.etv.app.uninstall',
+  hasTenantWideExtension: 'pnp.etv.hasTenantWideExtension',
+  removeTenantWideExtension: 'pnp.etv.removeTenantWideExtension',
+  enableTenantWideExtension: 'pnp.etv.enableTenantWideExtension',
+  disableTenantWideExtension: 'pnp.etv.disableTenantWideExtension'
 };

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -189,7 +189,13 @@ export class CommandPanel {
           if (tenantWideExtensions && tenantWideExtensions.length > 0) {
             tenantWideExtensions.forEach((extension) => {
               tenantWideExtensionsList.push(
-                new ActionTreeItem(extension.Title, '', { name: 'spo-app', custom: true }, TreeItemCollapsibleState.None, 'vscode.open', Uri.parse(extension.Url), 'sp-app-catalog-tenant-wide-extensions-url')
+                new ActionTreeItem(extension.Title, '', { name: 'spo-app', custom: true }, TreeItemCollapsibleState.None, 'vscode.open', Uri.parse(extension.Url), ContextKeys.hasTenantWideExtension,
+                  [
+                    new ActionTreeItem('Remove', '', undefined, undefined, Commands.removeTenantWideExtension, [extension.Title, extension.Url, tenantAppCatalogUrl], ContextKeys.removeTenantWideExtension),
+                    new ActionTreeItem('Enable', '', undefined, undefined, Commands.enableTenantWideExtension, [extension.Title, extension.Url, tenantAppCatalogUrl, extension.IsDisabled], ContextKeys.enableTenantWideExtension),
+                    new ActionTreeItem('Disable', '', undefined, undefined, Commands.disableTenantWideExtension, [extension.Title, extension.Url, tenantAppCatalogUrl, extension.IsDisabled], ContextKeys.disableTenantWideExtension),
+                  ]
+                )
               );
             });
           } else {

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -192,8 +192,8 @@ export class CommandPanel {
                 new ActionTreeItem(extension.Title, '', { name: 'spo-app', custom: true }, TreeItemCollapsibleState.None, 'vscode.open', Uri.parse(extension.Url), ContextKeys.hasTenantWideExtension,
                   [
                     new ActionTreeItem('Remove', '', undefined, undefined, Commands.removeTenantWideExtension, [extension.Title, extension.Url, tenantAppCatalogUrl], ContextKeys.removeTenantWideExtension),
-                    new ActionTreeItem('Enable', '', undefined, undefined, Commands.enableTenantWideExtension, [extension.Title, extension.Url, tenantAppCatalogUrl, extension.IsDisabled], ContextKeys.enableTenantWideExtension),
-                    new ActionTreeItem('Disable', '', undefined, undefined, Commands.disableTenantWideExtension, [extension.Title, extension.Url, tenantAppCatalogUrl, extension.IsDisabled], ContextKeys.disableTenantWideExtension),
+                    new ActionTreeItem('Enable', '', undefined, undefined, Commands.enableTenantWideExtension, [extension.Title, extension.Url, tenantAppCatalogUrl, extension.extensionDisabled], ContextKeys.enableTenantWideExtension),
+                    new ActionTreeItem('Disable', '', undefined, undefined, Commands.disableTenantWideExtension, [extension.Title, extension.Url, tenantAppCatalogUrl, extension.extensionDisabled], ContextKeys.disableTenantWideExtension),
                   ]
                 )
               );

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -123,7 +123,7 @@ export class CliActions {
    * @returns A promise that resolves to an array of objects containing the URL and title of each tenant-wide extension,
    *          or undefined if no extensions are found.
    */
-  public static async getTenantWideExtensions(tenantAppCatalogUrl: string): Promise<{ Url: string, Title: string, IsDisabled: boolean }[] | undefined> {
+  public static async getTenantWideExtensions(tenantAppCatalogUrl: string): Promise<{ Url: string, Title: string, extensionDisabled: boolean }[] | undefined> {
     const origin = new URL(tenantAppCatalogUrl).origin;
     const commandOptions: any = {
       listUrl: `${tenantAppCatalogUrl.replace(origin, '')}/Lists/TenantWideExtensions`,
@@ -141,7 +141,7 @@ export class CliActions {
         return {
           Url: `${tenantAppCatalogUrl}/Lists/TenantWideExtensions/DispForm.aspx?ID=${extension.Id}`,
           Title: extension.Title,
-          IsDisabled: extension.TenantWideExtensionDisabled || false
+          extensionDisabled: extension.TenantWideExtensionDisabled || false
         };
       });
       return tenantWideExtensionList;

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -123,7 +123,7 @@ export class CliActions {
    * @returns A promise that resolves to an array of objects containing the URL and title of each tenant-wide extension,
    *          or undefined if no extensions are found.
    */
-  public static async getTenantWideExtensions(tenantAppCatalogUrl: string): Promise<{ Url: string, Title: string }[] | undefined> {
+  public static async getTenantWideExtensions(tenantAppCatalogUrl: string): Promise<{ Url: string, Title: string, IsDisabled: boolean }[] | undefined> {
     const origin = new URL(tenantAppCatalogUrl).origin;
     const commandOptions: any = {
       listUrl: `${tenantAppCatalogUrl.replace(origin, '')}/Lists/TenantWideExtensions`,
@@ -140,7 +140,8 @@ export class CliActions {
       const tenantWideExtensionList = tenantWideExtensionsJson.map((extension) => {
         return {
           Url: `${tenantAppCatalogUrl}/Lists/TenantWideExtensions/DispForm.aspx?ID=${extension.Id}`,
-          Title: extension.Title
+          Title: extension.Title,
+          IsDisabled: extension.TenantWideExtensionDisabled || false
         };
       });
       return tenantWideExtensionList;
@@ -320,9 +321,9 @@ export class CliActions {
     return result.stdout;
   }
 
- /**
-   * Sets the form customizer for a content type on a list.
-   */
+  /**
+    * Sets the form customizer for a content type on a list.
+    */
   public static async setFormCustomizer() {
     const relativeUrl = await window.showInputBox({
       prompt: 'Enter the relative URL of the site',
@@ -423,11 +424,11 @@ export class CliActions {
     });
   }
 
-/**
-   * Adds a Tenant App Catalog.
-   * The URL is fixed to "https://domain.sharepoint.com/sites/appcatalog".
-   * Prompts the user for the owner and timeZone.
-   */
+  /**
+     * Adds a Tenant App Catalog.
+     * The URL is fixed to "https://domain.sharepoint.com/sites/appcatalog".
+     * Prompts the user for the owner and timeZone.
+     */
   public static async addTenantAppCatalog() {
     const tenantUrl = EnvironmentInformation.tenantUrl;
     if (!tenantUrl) {
@@ -518,7 +519,8 @@ export class CliActions {
             return 'Please provide a relative URL without a leading slash.';
           }
           return undefined;
-        }});
+        }
+      });
 
       if (!relativeUrl) {
         Notifications.warning('No site URL provided. Operation aborted.');

--- a/src/services/actions/SpfxAppCLIActions.ts
+++ b/src/services/actions/SpfxAppCLIActions.ts
@@ -49,6 +49,19 @@ export class SpfxAppCLIActions {
         subscriptions.push(
             commands.registerCommand(Commands.upgradeAppCatalogApp, SpfxAppCLIActions.upgradeAppCatalogApp)
         );
+        subscriptions.push(
+            commands.registerCommand(Commands.removeTenantWideExtension, SpfxAppCLIActions.removeTenantWideExtension)
+        );
+        subscriptions.push(
+            commands.registerCommand(Commands.enableTenantWideExtension, (node: ActionTreeItem) =>
+                SpfxAppCLIActions.toggleExtensionEnabled(node, ContextKeys.enableTenantWideExtension, 'enable')
+            )
+        );
+        subscriptions.push(
+            commands.registerCommand(Commands.disableTenantWideExtension, (node: ActionTreeItem) =>
+                SpfxAppCLIActions.toggleExtensionEnabled(node, ContextKeys.disableTenantWideExtension, 'disable')
+            )
+        );
     }
 
     /**
@@ -393,9 +406,7 @@ export class SpfxAppCLIActions {
                 canPickMany: false
             });
 
-            const shouldRemoveAnswer = shouldRemove === 'Yes';
-
-            if (!shouldRemoveAnswer) {
+            if (shouldRemove !== 'Yes') {
                 return;
             }
 
@@ -417,6 +428,124 @@ export class SpfxAppCLIActions {
             });
 
             Notifications.info(`App '${appTitle}' has been successfully removed.`);
+
+            // refresh the environmentTreeView
+            await commands.executeCommand('spfx-toolkit.refreshAppCatalogTreeView');
+        } catch (e: any) {
+            const message = e?.error?.message;
+            Notifications.error(message);
+        }
+    }
+
+    /**
+     * Removes a tenant-wide extension.
+     *
+     * @param node The tree item representing the tenant-wide extension to be removed.
+     */
+    public static async removeTenantWideExtension(node: ActionTreeItem) {
+        try {
+            const actionNode = node.children?.find(child => child.contextValue === ContextKeys.removeTenantWideExtension);
+
+            if (!actionNode?.command?.arguments) {
+                Notifications.error('Failed to retrieve the extension details for removal.');
+                return;
+            }
+
+            const [extensionTitle, extensionUrl, tenantAppCatalogUrl] = actionNode.command.arguments;
+
+            const shouldRemove = await window.showQuickPick(['Yes', 'No'], {
+                title: `Are you sure you want to remove the app '${extensionTitle}' from the Tenant Wide Extensions list?`,
+                ignoreFocusOut: true,
+                canPickMany: false
+            });
+
+            if (shouldRemove !== 'Yes') {
+                return;
+            }
+
+            const url = new URL(extensionUrl);
+            const extensionId = url.searchParams.get('ID');
+            if (!extensionId) {
+                Notifications.error('Failed to retrieve the extension ID from the extension URL.');
+                return;
+            }
+
+            const commandOptionsSet: any = {
+                listUrl: `${tenantAppCatalogUrl.replace(new URL(tenantAppCatalogUrl).origin, '')}/Lists/TenantWideExtensions`,
+                webUrl: tenantAppCatalogUrl,
+                id: extensionId,
+                force: true
+            };
+
+            await window.withProgress({
+                location: ProgressLocation.Notification,
+                title: `Removing Tenant Wide Extension... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
+                cancellable: true
+            }, async () => {
+                await CliExecuter.execute('spo listitem remove', 'json', commandOptionsSet);
+            });
+
+            Notifications.info(`Tenant Wide Extension '${extensionTitle}' has been successfully removed.`);
+
+            // refresh the environmentTreeView
+            await commands.executeCommand('spfx-toolkit.refreshAppCatalogTreeView');
+        } catch (e: any) {
+            const message = e?.error?.message;
+            Notifications.error(message);
+        }
+    }
+
+    /**
+     * Enables or disables a tenant-wide extension.
+     *
+     * @param node The tree item representing the tenant-wide extension to be enabled or disabled.
+     * @param ctxValue The context value used to identify the action node.
+     * @param action The action to be performed: 'enable' or 'disable'.
+     */
+    public static async toggleExtensionEnabled(node: ActionTreeItem, ctxValue: string, action: 'enable' | 'disable') {
+        try {
+            const actionNode = node.children?.find(child => child.contextValue === ctxValue);
+
+            if (!actionNode?.command?.arguments) {
+                Notifications.error(`Failed to retrieve the extension details for ${action}.`);
+                return;
+            }
+
+            const [extensionTitle, extensionUrl, tenantAppCatalogUrl, isDisabled] = actionNode.command.arguments;
+
+            if (action === 'enable' && !isDisabled) {
+                Notifications.info(`Extension '${extensionTitle}' is already enabled.`);
+                return;
+            }
+
+            if (action === 'disable' && isDisabled) {
+                Notifications.info(`Extension '${extensionTitle}' is already disabled.`);
+                return;
+            }
+
+            const url = new URL(extensionUrl);
+            const extensionId = url.searchParams.get('ID');
+            if (!extensionId) {
+                Notifications.error('Failed to retrieve the extension ID from the extension URL.');
+                return;
+            }
+
+            const commandOptionsSet: any = {
+                listUrl: `${tenantAppCatalogUrl.replace(new URL(tenantAppCatalogUrl).origin, '')}/Lists/TenantWideExtensions`,
+                id: extensionId,
+                webUrl: tenantAppCatalogUrl,
+                TenantWideExtensionDisabled: isDisabled ? false : true
+            };
+
+            await window.withProgress({
+                location: ProgressLocation.Notification,
+                title: `${action === 'enable' ? 'Enabling' : 'Disabling'} tenant-wide extension... Check [output window](command:${Commands.showOutputChannel}) to follow the progress.`,
+                cancellable: true
+            }, async () => {
+                await CliExecuter.execute('spo listitem set', 'json', commandOptionsSet);
+            });
+
+            Notifications.info(`Extension '${extensionTitle}' has been successfully ${action === 'enable' ? 'enabled' : 'disabled'}.`);
 
             // refresh the environmentTreeView
             await commands.executeCommand('spfx-toolkit.refreshAppCatalogTreeView');


### PR DESCRIPTION
## 🎯 Aim

> This PR adds new management capabilities for Tenant Wide Extensions in the SPFx Toolkit

## 📷 Result

![image](https://github.com/user-attachments/assets/6394abe6-a12b-4334-9024-90d691fdb7f9)

## ✅ What was done

> clarify what was done and what still needs to be finished ex. [Remove this line]

- [X] Added support to enable or disable Tenant Wide Extensions from the app catalog tree
- [X] Added support to remove Tenant Wide Extensions
- [ ] Removing a Tenant Wide Extension does **not** remove the app as the extension may be part of a larger solution with other components. However, removing an app does remove the associated tenant-wide extension (if any) 

## 🔗 Related issue

Closes: #435