### PR TITLE
Adds new settings to set shell type for spfx project upgrade command. Closes #525

### DIFF
--- a/package.json
+++ b/package.json
@@ -516,13 +516,13 @@
 				"spfx-toolkit.upgradeShellType": {
 					"title": "Project upgrade shell type",
 					"type": "string",
-					"default": "bash",
+					"default": "powershell",
 					"enum": [
 						"bash",
 						"powershell",
 						"cmd"
 					],
-					"description": "Choose the shell type to be used for the upgrade command. You can choose between `bash`, `powershell`, or `cmd`."
+					"description": "Choose the shell type to be used for the upgrade action. You can choose between `bash`, `powershell`, or `cmd`."
 				},
 				"spfx-toolkit.projectValidateOutputMode": {
 					"title": "Project validate output mode",

--- a/package.json
+++ b/package.json
@@ -513,6 +513,17 @@
 					],
 					"description": "Choose the output mode for the project upgrade. You can choose between `both`, `markdown`, or `code tour`."
 				},
+				"spfx-toolkit.upgradeShellType": {
+					"title": "Project upgrade shell type",
+					"type": "string",
+					"default": "bash",
+					"enum": [
+						"bash",
+						"powershell",
+						"cmd"
+					],
+					"description": "Choose the shell type to be used for the upgrade command. You can choose between `bash`, `powershell`, or `cmd`."
+				},
 				"spfx-toolkit.projectValidateOutputMode": {
 					"title": "Project validate output mode",
 					"type": "string",

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -631,14 +631,19 @@ export class CliActions {
     }, async (progress: Progress<{ message?: string; increment?: number }>) => {
       try {
         const projectUpgradeOutputMode: string = getExtensionSettings('projectUpgradeOutputMode', 'both');
+        const projectUpgradeShellType: string = getExtensionSettings('upgradeShellType', 'bash');
+
+        const commandOptions: any = {
+          shell: projectUpgradeShellType
+        };
 
         if (projectUpgradeOutputMode === 'markdown' || projectUpgradeOutputMode === 'both') {
-          const resultMd = await CliExecuter.execute('spfx project upgrade', 'md');
+          const resultMd = await CliExecuter.execute('spfx project upgrade', 'md', commandOptions);
           CliActions.handleMarkdownResult(resultMd, wsFolder, 'upgrade');
         }
 
         if (projectUpgradeOutputMode === 'code tour' || projectUpgradeOutputMode === 'both') {
-          await CliExecuter.execute('spfx project upgrade', 'tour');
+          await CliExecuter.execute('spfx project upgrade', 'tour', commandOptions);
           CliActions.handleTourResult(wsFolder, 'upgrade');
         }
       } catch (e: any) {

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -631,7 +631,7 @@ export class CliActions {
     }, async (progress: Progress<{ message?: string; increment?: number }>) => {
       try {
         const projectUpgradeOutputMode: string = getExtensionSettings('projectUpgradeOutputMode', 'both');
-        const projectUpgradeShellType: string = getExtensionSettings('upgradeShellType', 'bash');
+        const projectUpgradeShellType: string = getExtensionSettings('upgradeShellType', 'powershell');
 
         const commandOptions: any = {
           shell: projectUpgradeShellType


### PR DESCRIPTION
## 🎯 Aim

This PR adds support for configuring the shell type for `SPFx project upgrade` action. This setting allows users to specify their preferred shell when generating upgrade steps.

## 📷 Result

<img width="1448" height="197" alt="image" src="https://github.com/user-attachments/assets/043dc9ad-8ba8-4fc9-ba3e-8247ce9a8d30" />

## ✅ What was done

- [X] Added a new VS Code setting `spfx-toolkit.upgradeShellType` and passed it to `spfx project upgrade` CLI command

## 🔗 Related issue

Closes: #525