### PR TITLE
Add copy/move app actions. Closes #373

### DIFF
--- a/package.json
+++ b/package.json
@@ -767,6 +767,18 @@
 				"icon": "$(remove)"
 			},
 			{
+				"command": "spfx-toolkit.copyAppCatalogApp",
+				"title": "Copy",
+				"category": "SPFx Toolkit",
+				"icon": "$(package)"
+			},
+			{
+				"command": "spfx-toolkit.moveAppCatalogApp",
+				"title": "Move",
+				"category": "SPFx Toolkit",
+				"icon": "$(package)"
+			},
+			{
 				"command": "spfx-toolkit.setFormCustomizer",
 				"title": "Set Form Customizer",
 				"category": "SPFx Toolkit"
@@ -935,6 +947,14 @@
 					"when": "false"
 				},
 				{
+					"command": "spfx-toolkit.copyAppCatalogApp",
+					"when": "false"
+				},
+				{
+					"command": "spfx-toolkit.moveAppCatalogApp",
+					"when": "false"
+				},
+				{
 					"command": "spfx-toolkit.moreTenantWideExtensionActions",
 					"when": "false"
 				},
@@ -1006,36 +1026,44 @@
 			],
 			"spfx-toolkit.showMoreActions": [
 				{
+					"command": "spfx-toolkit.copyAppCatalogApp",
+					"group": "actions.more@1"
+				},
+				{
 					"command": "spfx-toolkit.deployAppCatalogApp",
-					"group": "actions.more@1"
-				},
-				{
-					"command": "spfx-toolkit.retractAppCatalogApp",
-					"group": "actions.more@1"
-				},
-				{
-					"command": "spfx-toolkit.removeAppCatalogApp",
 					"group": "actions.more@2"
 				},
 				{
-					"command": "spfx-toolkit.enableAppCatalogApp",
+					"command": "spfx-toolkit.disableAppCatalogApp",
 					"group": "actions.more@3"
 				},
 				{
-					"command": "spfx-toolkit.disableAppCatalogApp",
+					"command": "spfx-toolkit.enableAppCatalogApp",
 					"group": "actions.more@4"
-				},
-				{
-					"command": "spfx-toolkit.upgradeAppCatalogApp",
-					"group": "actions.more@5"
 				},
 				{
 					"command": "spfx-toolkit.installAppCatalogApp",
 					"group": "actions.more@5"
 				},
 				{
+					"command": "spfx-toolkit.moveAppCatalogApp",
+					"group": "actions.more@6"
+				},
+				{
+					"command": "spfx-toolkit.removeAppCatalogApp",
+					"group": "actions.more@7"
+				},
+				{
+					"command": "spfx-toolkit.retractAppCatalogApp",
+					"group": "actions.more@8"
+				},
+				{
 					"command": "spfx-toolkit.uninstallAppCatalogApp",
-					"group": "actions.more@5"
+					"group": "actions.more@9"
+				},
+				{
+					"command": "spfx-toolkit.upgradeAppCatalogApp",
+					"group": "actions.more@10"
 				}
 			],
 			"spfx-toolkit.moreTenantWideExtensionActions": [

--- a/src/constants/Commands.ts
+++ b/src/constants/Commands.ts
@@ -92,6 +92,8 @@ export const Commands = {
   upgradeAppCatalogApp: `${EXTENSION_NAME}.upgradeAppCatalogApp`,
   installAppCatalogApp: `${EXTENSION_NAME}.installAppCatalogApp`,
   uninstallAppCatalogApp: `${EXTENSION_NAME}.uninstallAppCatalogApp`,
+  copyAppCatalogApp: `${EXTENSION_NAME}.copyAppCatalogApp`,
+  moveAppCatalogApp: `${EXTENSION_NAME}.moveAppCatalogApp`,
   showMoreActions: `${EXTENSION_NAME}.showMoreActions`,
 
   // App Catalog actions

--- a/src/constants/ContextKeys.ts
+++ b/src/constants/ContextKeys.ts
@@ -16,5 +16,7 @@ export const ContextKeys = {
   removeTenantWideExtension: 'pnp.etv.removeTenantWideExtension',
   enableTenantWideExtension: 'pnp.etv.enableTenantWideExtension',
   disableTenantWideExtension: 'pnp.etv.disableTenantWideExtension',
-  updateTenantWideExtension: 'pnp.etv.updateTenantWideExtension'
+  updateTenantWideExtension: 'pnp.etv.updateTenantWideExtension',
+  copyApp: 'pnp.etv.app.copy',
+  moveApp: 'pnp.etv.app.move'
 };

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -204,14 +204,16 @@ export class CommandPanel {
               tenantAppCatalogAppsList.push(
                 new ActionTreeItem(app.Title, '', { name: 'package', custom: false }, undefined, 'vscode.open', Uri.parse(appStoreUrl), ContextKeys.hasAppCatalogApp,
                   [
+                    new ActionTreeItem('Copy', '', undefined, undefined, Commands.copyAppCatalogApp, [app.ID, app.Title, tenantAppCatalogUrl, appCatalogUrls], ContextKeys.copyApp),
                     new ActionTreeItem('Deploy', '', undefined, undefined, Commands.deployAppCatalogApp, [app.ID, app.Title, undefined, app.Deployed], ContextKeys.deployApp),
-                    new ActionTreeItem('Retract', '', undefined, undefined, Commands.retractAppCatalogApp, [app.ID, app.Title, undefined, app.Deployed], ContextKeys.retractApp),
-                    new ActionTreeItem('Remove', '', undefined, undefined, Commands.removeAppCatalogApp, [app.ID, app.Title], ContextKeys.removeApp),
-                    new ActionTreeItem('Enable', '', undefined, undefined, Commands.enableAppCatalogApp, [app.Title, tenantAppCatalogUrl, app.Enabled], ContextKeys.enableApp),
                     new ActionTreeItem('Disable', '', undefined, undefined, Commands.disableAppCatalogApp, [app.Title, tenantAppCatalogUrl, app.Enabled], ContextKeys.disableApp),
-                    new ActionTreeItem('Upgrade', '', undefined, undefined, Commands.upgradeAppCatalogApp, [app.ID, app.Title, tenantAppCatalogUrl, true], ContextKeys.upgradeApp),
+                    new ActionTreeItem('Enable', '', undefined, undefined, Commands.enableAppCatalogApp, [app.Title, tenantAppCatalogUrl, app.Enabled], ContextKeys.enableApp),
                     new ActionTreeItem('Install', '', undefined, undefined, Commands.installAppCatalogApp, [app.ID, app.Title], ContextKeys.installApp),
-                    new ActionTreeItem('Uninstall', '', undefined, undefined, Commands.uninstallAppCatalogApp, [app.ID, app.Title], ContextKeys.uninstallApp)
+                    new ActionTreeItem('Move', '', undefined, undefined, Commands.moveAppCatalogApp, [app.ID, app.Title, tenantAppCatalogUrl, appCatalogUrls], ContextKeys.moveApp),
+                    new ActionTreeItem('Remove', '', undefined, undefined, Commands.removeAppCatalogApp, [app.ID, app.Title], ContextKeys.removeApp),
+                    new ActionTreeItem('Retract', '', undefined, undefined, Commands.retractAppCatalogApp, [app.ID, app.Title, undefined, app.Deployed], ContextKeys.retractApp),
+                    new ActionTreeItem('Uninstall', '', undefined, undefined, Commands.uninstallAppCatalogApp, [app.ID, app.Title], ContextKeys.uninstallApp),
+                    new ActionTreeItem('Upgrade', '', undefined, undefined, Commands.upgradeAppCatalogApp, [app.ID, app.Title, tenantAppCatalogUrl, true], ContextKeys.upgradeApp)
                   ]
                 )
               );
@@ -246,14 +248,16 @@ export class CommandPanel {
                 siteAppCatalogAppsList.push(
                   new ActionTreeItem(app.Title, '', { name: 'package', custom: false }, undefined, 'vscode.open', Uri.parse(appStoreUrl), ContextKeys.hasAppCatalogApp,
                     [
+                      new ActionTreeItem('Copy', '', undefined, undefined, Commands.copyAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, appCatalogUrls], ContextKeys.copyApp),
                       new ActionTreeItem('Deploy', '', undefined, undefined, Commands.deployAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, app.Deployed], ContextKeys.deployApp),
-                      new ActionTreeItem('Retract', '', undefined, undefined, Commands.retractAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, app.Deployed], ContextKeys.retractApp),
-                      new ActionTreeItem('Remove', '', undefined, undefined, Commands.removeAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl], ContextKeys.removeApp),
-                      new ActionTreeItem('Enable', '', undefined, undefined, Commands.enableAppCatalogApp, [app.Title, siteAppCatalogUrl, app.Enabled], ContextKeys.enableApp),
                       new ActionTreeItem('Disable', '', undefined, undefined, Commands.disableAppCatalogApp, [app.Title, siteAppCatalogUrl, app.Enabled], ContextKeys.disableApp),
-                      new ActionTreeItem('Upgrade', '', undefined, undefined, Commands.upgradeAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, false], ContextKeys.upgradeApp),
+                      new ActionTreeItem('Enable', '', undefined, undefined, Commands.enableAppCatalogApp, [app.Title, siteAppCatalogUrl, app.Enabled], ContextKeys.enableApp),
                       new ActionTreeItem('Install', '', undefined, undefined, Commands.installAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl], ContextKeys.installApp),
-                      new ActionTreeItem('Uninstall', '', undefined, undefined, Commands.uninstallAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl], ContextKeys.uninstallApp)
+                      new ActionTreeItem('Move', '', undefined, undefined, Commands.moveAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, appCatalogUrls], ContextKeys.moveApp),
+                      new ActionTreeItem('Remove', '', undefined, undefined, Commands.removeAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl], ContextKeys.removeApp),
+                      new ActionTreeItem('Retract', '', undefined, undefined, Commands.retractAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, app.Deployed], ContextKeys.retractApp),
+                      new ActionTreeItem('Uninstall', '', undefined, undefined, Commands.uninstallAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl], ContextKeys.uninstallApp),
+                      new ActionTreeItem('Upgrade', '', undefined, undefined, Commands.upgradeAppCatalogApp, [app.ID, app.Title, siteAppCatalogUrl, false], ContextKeys.upgradeApp)
                     ]
                   )
                 );

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -68,16 +68,24 @@ export class CliActions {
       const tenantAppCatalog = (await CliExecuter.execute('spo tenant appcatalogurl get', 'json')).stdout || undefined;
       const siteAppCatalogs = (await CliExecuter.execute('spo site appcatalog list', 'json', { excludeDeletedSites: true })).stdout || undefined;
 
+      let tenantUrl: string | undefined;
       if (tenantAppCatalog) {
-        appCatalogUrls.push(JSON.parse(tenantAppCatalog));
+        tenantUrl = JSON.parse(tenantAppCatalog);
+        if (tenantUrl) {
+          appCatalogUrls.push(tenantUrl);
+        }
       }
 
       if (siteAppCatalogs) {
         const siteAppCatalogsJson: SiteAppCatalog[] = JSON.parse(siteAppCatalogs);
-        siteAppCatalogsJson.forEach((siteAppCatalog) => appCatalogUrls.push(`${siteAppCatalog.AbsoluteUrl}`));
+        siteAppCatalogsJson.forEach((siteAppCatalog) => {
+          if (!tenantUrl || siteAppCatalog.AbsoluteUrl !== tenantUrl) {
+            appCatalogUrls.push(`${siteAppCatalog.AbsoluteUrl}`);
+          }
+        });
       }
 
-      EnvironmentInformation.appCatalogUrls = appCatalogUrls ? appCatalogUrls : undefined;
+      EnvironmentInformation.appCatalogUrls = appCatalogUrls.length > 0 ? appCatalogUrls : undefined;
       return EnvironmentInformation.appCatalogUrls;
     } catch {
       return undefined;


### PR DESCRIPTION
## 🎯 Aim

This PR adds two new actions to enhance app management capabilities.

## 📷 Result

<img width="1097" height="524" alt="image" src="https://github.com/user-attachments/assets/4c17b60a-37ca-4df7-b04e-3db8fab19372" />


## ✅ What was done

- [X] Added Copy/Move actions
- [X] Reordered actions alphabetically
- [X] Updated appCatalogUrlsGet to ensure tenant app catalog URL is not returned twice

## 🔗 Related issue

Closes: #373