### PR TITLE
Adds CLI for Microsoft 365 package clean up

### DIFF
--- a/scripts/cli-for-microsoft365-copy-local-version.ps1
+++ b/scripts/cli-for-microsoft365-copy-local-version.ps1
@@ -14,5 +14,18 @@ if (Test-Path -Path $cliPackagePath -PathType Container && Test-Path -Path $cliL
         Write-Host "Removing eslint-plugin-cli-microsoft365 folder..."
         Remove-Item -Path $eslintPluginPath -Recurse -Force
     }
+
+    # Remove all .spec.js and .js.map files from the package folder
+    Write-Host "Removing .spec.js and .js.map files..."
+    Get-ChildItem -Path "$cliPackagePath\dist" -Recurse -Include *.spec.js, *.js.map | ForEach-Object {
+        Remove-Item -Path $_.FullName -Force
+    }
+
+    # Remove docs folder
+    $docsFolderPath = "$cliPackagePath\docs"
+    if (Test-Path -Path $docsFolderPath -PathType Container) {
+        Write-Host "Removing docs folder..."
+        Remove-Item -Path $docsFolderPath -Recurse -Force
+    }
 }
 


### PR DESCRIPTION
## 🎯 Aim

The aim is to perform clean up of CLI for Microsoft 365 npm package not to include any docs, spec.js and js.map files in the final vs code extension bundle 

## ✅ What was done

- [X] updated CLI for Microsoft 365 copy PowerShell script
