### PR TITLE
Adds try catch safe guards in sample gallery. Closes #603

### DIFF
--- a/src/webview/view/hooks/useSamples.tsx
+++ b/src/webview/view/hooks/useSamples.tsx
@@ -73,8 +73,20 @@ export default function useSamples(): [Sample[], string[], ((query: string, comp
       return;
     }
     const samplesByTitle: Sample[] = currentSamples!.filter((sample: Sample) => sample.title.toString().toLowerCase().includes(query.toLowerCase()));
-    const samplesByTag: Sample[] = currentSamples!.filter((sample: Sample) => sample.tags.some(tag => tag.toString().toLowerCase().includes(query.toLowerCase())));
-    const samplesByAuthor: Sample[] = currentSamples!.filter((sample: Sample) => sample.authors.some(author => author.name && author.name.toString().toLowerCase().includes(query.toLowerCase())));
+    const samplesByTag: Sample[] = currentSamples!.filter((sample: Sample) => {
+      try {
+        return sample.tags.some(tag => tag.toString().toLowerCase().includes(query.toLowerCase()));
+      } catch {
+        return false;
+      }
+    });
+    const samplesByAuthor: Sample[] = currentSamples!.filter((sample: Sample) => {
+      try {
+        return sample.authors.some(author => author.name && author.name.toString().toLowerCase().includes(query.toLowerCase()));
+      } catch {
+        return false;
+      }
+    });
     let newSamples: Sample[] = samplesByTitle.concat(samplesByTag).concat(samplesByAuthor);
     if (showOnlyScenarios){
       newSamples = newSamples.filter((sample: Sample) => sample.sampleType === 'scenarios');


### PR DESCRIPTION
## 🎯 Aim

Adds try catch block for tags and authors filtering to prevent future errors if some of those collections will be defined in json as `null` instead of `[]`

## 📷 Result

<img width="1760" height="958" alt="image" src="https://github.com/user-attachments/assets/b9fd4c5d-6986-429d-ab81-1386bbfe277c" />

## ✅ What was done

- [X] Added try catch safe guards in sample gallery. 

## 🔗 Related issue

Closes: #603