### PR TITLE
Add CLI for Microsoft 365 MCP server

### DIFF
--- a/src/panels/HelpTreeData.ts
+++ b/src/panels/HelpTreeData.ts
@@ -16,6 +16,7 @@ export const helpCommands: ActionTreeItem[] = [
         new ActionTreeItem('Microsoft Graph Explorer', '', { name: 'globe', custom: false }, undefined, 'vscode.open', Uri.parse('https://developer.microsoft.com/en-us/graph/graph-explorer')),
         new ActionTreeItem('Microsoft 365 Agents Toolkit', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension')),
         new ActionTreeItem('Adaptive Card Previewer', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.vscode-adaptive-cards')),
+        new ActionTreeItem('CLI for Microsoft 365 MCP server', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://github.com/pnp/cli-microsoft365-mcp-server')),
         new ActionTreeItem('SharePoint Embedded', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=SharepointEmbedded.ms-sharepoint-embedded-vscode-extension')),
         new ActionTreeItem('Adaptive Card Designer', '', { name: 'globe', custom: false }, undefined, 'vscode.open', Uri.parse('https://adaptivecards.microsoft.com/designer')),
         new ActionTreeItem('Join the Microsoft 365 Developer Program', '', { name: 'star-empty', custom: false }, undefined, 'vscode.open', Uri.parse('https://developer.microsoft.com/en-us/microsoft-365/dev-program')),

--- a/src/test/suite/helpView.test.ts
+++ b/src/test/suite/helpView.test.ts
@@ -73,6 +73,7 @@ suite('Help and feedback', () => {
             'Microsoft Graph Explorer',
             'Microsoft 365 Agents Toolkit',
             'Adaptive Card Previewer',
+            'CLI for Microsoft 365 MCP server',
             'SharePoint Embedded',
             'Adaptive Card Designer',
             'Join the Microsoft 365 Developer Program',
@@ -175,6 +176,10 @@ suite('Help and feedback', () => {
             {
                 label: 'Adaptive Card Previewer',
                 url: 'https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.vscode-adaptive-cards'
+            },
+            {
+                label: 'CLI for Microsoft 365 MCP server',
+                url: 'https://github.com/pnp/cli-microsoft365-mcp-server'
             },
             {
                 label: 'SharePoint Embedded',


### PR DESCRIPTION
## 🎯 Aim

Add a link to the CLI for Microsoft 365 MCP server in the Help and Feedback view under the Resources & Tooling section.

## 📷 Result

<img width="483" height="582" alt="image" src="https://github.com/user-attachments/assets/51d890cc-bdbb-4855-a681-93f44c300b1f" />


## ✅ What was done

> clarify what was done and what still needs to be finished ex. [Remove this line]

- [X] Added "CLI for Microsoft 365 MCP server" link to HelpTreeData.ts in Resources & Tooling section
- [X] Updated tests in helpView.test.ts to include the new link in expected items

## 🔗 Related issue

Closes: #581 