### PR TITLE
Fixes sample gallery script. Closes #615

### DIFF
--- a/scripts/prepare-sample-data.ps1
+++ b/scripts/prepare-sample-data.ps1
@@ -87,7 +87,7 @@ function Parse-SampleJsonFiles {
                     version       = $version;  
                     componentType = $componentType;
                     extensionType = $extensionType;       
-                    sampleGallery = $sampleRepo
+                    sampleGallery = $sampleRepo;
                     sampleType    = $folder
                 }
             }


### PR DESCRIPTION
## 🎯 Aim

The aim of this change is to perform and update in the script that generates our sample gallery data so that when `products` does not exist in the sample.json we add an empty collection of tags instead of null

## 📷 Result

<img width="1297" height="610" alt="image" src="https://github.com/user-attachments/assets/fe7de3c3-cbce-422d-a47a-0f5a21fdf674" />


## 🔗 Related issue

Closes: #615