### PR TITLE
Fixes Toolkit getting stuck during component creation if yo is not installed. Closes #580

### DIFF
--- a/src/constants/WebviewCommand.ts
+++ b/src/constants/WebviewCommand.ts
@@ -9,6 +9,7 @@ export const WebviewCommand = {
     nodeVersionManager: 'node-version-manager',
     nodeVersionManagerFile: 'node-version-manager-file',
     createNodeVersionManagerFile: 'node-version-manager-file',
+    resetFormState: 'reset-form-state',
   },
   toVSCode: {
     useSample: 'use-sample',

--- a/src/webview/view/components/forms/spfxProject/ScaffoldSpfxProjectView.tsx
+++ b/src/webview/view/components/forms/spfxProject/ScaffoldSpfxProjectView.tsx
@@ -41,6 +41,19 @@ export const ScaffoldSpfxProjectView: React.FunctionComponent<IScaffoldSpfxProje
   }, [location]);
 
   useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const message = event.data;
+      if (message.command === WebviewCommand.toWebview.resetFormState) {
+        setIsSubmitting(false);
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  useEffect(() => {
     if (isNewProject) {
       if (!folderPath || !solutionName || !componentName) {
         setIsFormValid(false);


### PR DESCRIPTION
## 🎯 Aim

Bug fix: Toolkit stuck during component creation if dependencies are not installed

## 📷 Result

  <img width="1917" height="1060" alt="image" src="https://github.com/user-attachments/assets/df7ca333-4b79-46db-a3b7-f8304d01081a" />

## ✅ What was done

- [] [this](https://github.com/pnp/vscode-viva/issues/580#issuecomment-3417022460) seemed unnecessary so not done
- [X] Added a new private method to validate `yo @microsoft/sharepoint` and notify
- [X] UI not stuck anymore in a loading state.

## 🔗 Related issue

Closes: #580