### PR TITLE
Resolve missing install-dependencies image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This action checks if your local development environment meets the required vers
 
 It is also possible to install the required Node.js version and global dependencies for any SPFx version using the **Install dependencies** action.
 
-![install dependencies](./assets/images/install-dependencies.png)
+![install dependencies](./docs/assets/images-vscode/Install-dependencies.png)
 
 >  [!NOTE]
 >  The list of valid dependencies is based on [set up your development environment recommendations](https://learn.microsoft.com/en-us/sharepoint/dev/spfx/set-up-your-development-environment)

--- a/assets/walkthrough/validate-local-setup.md
+++ b/assets/walkthrough/validate-local-setup.md
@@ -4,16 +4,16 @@ To build and deploy client-side web parts, extensions, or adaptive cards using t
 
 - **Validate Local Setup**: This action checks if your local development environment meets the required versions of Node.js and global dependencies for the SPFx version you have installed, and in case you do not have any SPFx generator installed, it will validate against the latest SPFx version.
 
-![validate dependencies](../images/validate-dependency.png)
+![validate dependencies](../../docs/assets/images-vscode/validate-dependency.png)
 
 - **Install Dependencies**: This action installs the required global dependencies for any SPFx version.
 
-![install dependencies](../images/install-dependencies.png)
+![install dependencies](../../docs/assets/images-vscode/Install-dependencies.png)
 
 SPFx Toolkit may also help you install and switch to the correct version of Node.js using either `nvm` (Node Version Manager) or `nvs` (Node Version Switcher). First you need to make sure you have set the Node.js Version Manager setting in SPFx Toolkit to either `nvm` or `nvs`.
 
 Then during installing dependencies, SPFx Toolkit will check if you have the correct version of Node.js installed, and if not, it will offer to install and switch to the correct version for you using the selected Node version manager.
 
-![node installation](../images/install-node-support.png)
+![node installation](../../docs/assets/images-vscode/install-node-support.png)
 
 Check out the [docs for more details](https://learn.microsoft.com/en-us/sharepoint/dev/spfx/set-up-your-development-environment) on the required node and dependency versions.


### PR DESCRIPTION
## 🎯 Aim

Resolve install dependencies image link which is broken in the readme file

## 📷 Result

 **Before:**


<img width="785" height="214" alt="image" src="https://github.com/user-attachments/assets/12808215-96d4-46d6-bc00-7263dd52280c" />

**After:**

<img width="798" height="662" alt="image" src="https://github.com/user-attachments/assets/260b365a-3ab6-4616-8a91-d7f12c940982" />


## ✅ What was done

The image path was incorrect. Added proper url which is now pointing towards the correct image.

- [X] Updated image path to correct image location

## 🔗 Related issue

Closes: #683 