### PR TITLE
Improve SPFx Project detection logic. Closes #627

### DIFF
--- a/scripts/prepare-sample-data.ps1
+++ b/scripts/prepare-sample-data.ps1
@@ -88,6 +88,7 @@ function Parse-SampleJsonFiles {
                         }
                     }
                     catch {
+                        Write-Warning "Failed to parse package.json for $($sample.FullName): $($_.Exception.Message)"
                     }
                 }
 

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -16,7 +16,7 @@ import { parseYoRc } from '../../utils/parseYoRc';
 import { parseCliCommand } from '../../utils/parseCliCommand';
 import { CertificateActions } from './CertificateActions';
 import path = require('path');
-import { getExtensionSettings, getPackageManager } from '../../utils';
+import { getExtensionSettings, getPackageManager, getVersion } from '../../utils';
 import * as fs from 'fs';
 import { ActionTreeItem } from '../../providers/ActionTreeDataProvider';
 import { timezones } from '../../constants/Timezones';
@@ -721,9 +721,8 @@ export class CliActions {
     }
 
     let toVersion: string | undefined;
-    const yoRc = await parseYoRc();
-    if (yoRc && yoRc['@microsoft/generator-sharepoint']?.version) {
-      const currentVersion = yoRc['@microsoft/generator-sharepoint']?.version;
+    const currentVersion = await getVersion();
+    if (currentVersion) {
       const currentVersionIndex = SpfxCompatibilityMatrix.findIndex(spfx => spfx.Version === currentVersion);
       const higherVersions = SpfxCompatibilityMatrix.slice(0, currentVersionIndex).map(spfx => spfx.Version);
 

--- a/src/utils/getVersion.ts
+++ b/src/utils/getVersion.ts
@@ -1,0 +1,19 @@
+import { parseYoRc } from './parseYoRc';
+import { parsePackageJson } from './parsePackageJson';
+
+
+export const getVersion = async (): Promise<string | undefined> => {
+    const yoRc = await parseYoRc();
+    if (yoRc?.['@microsoft/generator-sharepoint']?.version) {
+        return yoRc['@microsoft/generator-sharepoint'].version;
+    }
+
+    const packageJson = await parsePackageJson();
+    const spCoreLibVersion = packageJson?.dependencies?.['@microsoft/sp-core-library'];
+
+    if (spCoreLibVersion) {
+        return spCoreLibVersion.replace(/[\^~>=<]/g, '');
+    }
+
+    return undefined;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,3 +7,4 @@ export * from './getPackageManager';
 export * from './getInstallCommand';
 export * from './parseCliCommand';
 export * from './validateGuid';
+export * from './getVersion';

--- a/src/utils/parsePackageJson.ts
+++ b/src/utils/parsePackageJson.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'fs';
 import { workspace } from 'vscode';
 
 
@@ -20,7 +19,7 @@ export const parsePackageJson = async (): Promise<PackageJson | undefined> => {
         }
 
         const packageJsonFile = files[0];
-        const content = readFileSync(packageJsonFile.fsPath, 'utf8');
+        const content = await workspace.openTextDocument(packageJsonFile.fsPath).then(doc => doc.getText());
 
         if (!content) {
             return undefined;

--- a/src/utils/parseYoRc.ts
+++ b/src/utils/parseYoRc.ts
@@ -1,5 +1,6 @@
 import { workspace } from 'vscode';
 import { YoRc } from '../models';
+import { Logger } from '../services/dataType/Logger';
 
 
 export const parseYoRc = async (): Promise<YoRc | undefined> => {
@@ -22,7 +23,11 @@ export const parseYoRc = async (): Promise<YoRc | undefined> => {
     }
   }
 
-  content = typeof content === 'string' ? JSON.parse(content) as YoRc : content;
-
-  return content;
+  try {
+    content = typeof content === 'string' ? JSON.parse(content) as YoRc : content;
+    return content;
+  } catch (error) {
+    Logger.error(`Failed to parse .yo-rc.json: ${error}`);
+    return undefined;
+  }
 };


### PR DESCRIPTION
## 🎯 Aim

This PR implements two layer SPFx project detection logic. 

## 📷 Result

NA

## ✅ What was done

- [X] Implemented logic to check `.yo-rc.json` first and then falls back to `package.json` to check `@microsoft/sp-core-library`
- [X] Updated prepare-sample-data.ps1 to consider both approaches
- [] `extensionType` is set to `null` when `package.json` is used to detect SPFx project as I could not find find extensionType information

## 🔗 Related issue

Closes: #627 