### PR TITLE
Fixes nvm use error on Windows without version argument. Closes #519

### DIFF
--- a/src/services/executeWrappers/TerminalCommandExecuter.ts
+++ b/src/services/executeWrappers/TerminalCommandExecuter.ts
@@ -509,11 +509,17 @@ export class TerminalCommandExecuter {
         }
       } else if (nodeVersionManager === NodeVersionManagers.nvm) {
         if (nvmrcFiles.length > 0) {
-          const content = readFileSync(nvmrcFiles[0].fsPath, 'utf8').trim();
-          const version = content.startsWith('v') ? content.substring(1) : content;
-          if (version) {
-            terminal.sendText(`nvm use ${version}`);
-          } else {
+          const nvmrcPath = nvmrcFiles[0].fsPath;
+          try {
+            const content = readFileSync(nvmrcPath, 'utf8').trim();
+            const version = content.startsWith('v') ? content.substring(1) : content;
+            if (version) {
+              terminal.sendText(`nvm use ${version}`);
+            } else {
+              terminal.sendText('nvm use');
+            }
+          } catch (error) {
+            Logger.error(`Failed to read .nvmrc file at ${nvmrcPath}. Falling back to "nvm use" without version. Error: ${error}`);
             terminal.sendText('nvm use');
           }
         }


### PR DESCRIPTION
## 🎯 Aim

This PR fixes the `nvm use` error on Windows when creating a new SPFx project via the sample gallery. On Windows, `nvm-windows` does not automatically read the `.nvmrc`, so the command fails without a version argument. The fix parses the `.nvmrc` file and sends `nvm use <version>` with the version number for `nvm` users.. for `nvs` users it checks for both `.nvmrc` and `.node-version` files and sends `nvs use` which works on all platforms.

## 📷 Result

NA

## ✅ What was done

- [X] modified `createTerminal` method in `TerminalCommandExecuter.ts` as agreed in the issue 

## 🔗 Related issue

Closes: #519 