### PR TITLE
Updates extension startup. Closes #733

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 	],
 	"activationEvents": [
 		"workspaceContains:**/project.pnp",
+		"workspaceContains:**/config/package-solution.json",
 		"onView:pnp-view"
 	],
 	"extensionDependencies": [

--- a/src/services/actions/CliActions.ts
+++ b/src/services/actions/CliActions.ts
@@ -12,7 +12,6 @@ import { AuthProvider } from '../../providers/AuthProvider';
 import { CommandOutput } from '@pnp/cli-microsoft365-spfx-toolkit';
 import { M365AgentsToolkitIntegration } from '../dataType/M365AgentsToolkitIntegration';
 import { PnPWebview } from '../../webview/PnPWebview';
-import { parseCliCommand } from '../../utils/parseCliCommand';
 import { CertificateActions } from './CertificateActions';
 import path = require('path');
 import { getExtensionSettings, getPackageManager, getVersion, parsePackageJson } from '../../utils';


### PR DESCRIPTION
## 🎯 Aim

I know the related issue was still not agreed but this one is quite easy and hits on my nerve .😁
What I usually do is move the SPFx Toolkit Task Pane with heft and npm actions to the Explorer view so the tasks sit right along my files I modified. The problem is that this panel does not show up until the extension gets active so this happens only when we go to the SPFx Toolkit view. So this means every time I opened a SPFx project I had to go to the SPFx Toolkit view and then go back to the explorer view just to see the task panel. This is quite frustrating. 
Folks might have customized the look and feel of VS Code, like moving the login and management views to some other part of VS Code, In this case they would also need to go to the view to make them active. 
That Is why I propose to just check if a project has a config\package-solution.json file, and if so, we may assume it is a SPFx project and make the extension active. If it will still not be an SPFx project, this will be caught by the IsSpfx helper method in CommandPanels and will just load the SPFx Toolkit with the functionality when you are not in a SPFx project

## 📷 Result

<img width="684" height="788" alt="image" src="https://github.com/user-attachments/assets/bc8f7617-93b4-496d-803c-3a970457c254" />


## 🔗 Related issue

Closes: #733