### PR TITLE
Updates token handle. Closes #500

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@grconrad/vscode-extension-feedback": "^1.0.0",
-				"@pnp/cli-microsoft365-spfx-toolkit": "1.9.0",
+				"@pnp/cli-microsoft365-spfx-toolkit": "1.10.0",
 				"node-forge": "1.3.2",
 				"react-markdown": "10.1.0",
 				"rehype-raw": "7.0.0",
@@ -858,9 +858,9 @@
 			}
 		},
 		"node_modules/@pnp/cli-microsoft365-spfx-toolkit": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365-spfx-toolkit/-/cli-microsoft365-spfx-toolkit-1.9.0.tgz",
-			"integrity": "sha512-hlVdHl0a2Oqfhs82OeyxdvJWHrfrorfg0deCVvmMnQ8zclrjhJDxpGPxbGPNLYiycQLqtNAE/+LxGTGHKwU9Tw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365-spfx-toolkit/-/cli-microsoft365-spfx-toolkit-1.10.0.tgz",
+			"integrity": "sha512-Db0BpjAF6Q76UWsjpTcCuMRf4xHJqYvwKb93oQKQsoUyLy5GixPK89S7Z9RVWmRS+b66DDIY4ohvyJ1aJeKDWA==",
 			"hasShrinkwrap": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1609,7 +1609,7 @@
 	},
 	"dependencies": {
 		"@grconrad/vscode-extension-feedback": "^1.0.0",
-		"@pnp/cli-microsoft365-spfx-toolkit": "1.9.0",
+		"@pnp/cli-microsoft365-spfx-toolkit": "1.10.0",
 		"node-forge": "1.3.2",
 		"react-markdown": "10.1.0",
 		"remark-gfm": "4.0.1",


### PR DESCRIPTION
## 🎯 Aim

The aim is to fix the way we handle MSAL refresh token. Currently, in the extension, after we sign in, we are more or less logged in 1 hour and after that the access token expires, and we need to perform sign in again.
I noticed it was due to a simple bugi and the main origin and fix up was done and already published in CLI SPFx Toolkit npm package. No the token should allow to retain sign in from 4-90 days (depending on tenant settings)

In order to test this PR is best 
1. to uninstall SPFx Toolkit if you have it. 
2. Then use `vsce package` to build a local vscix package and install SPFx Toolkit from your local package. 
3. Next perform sign in
4. Wait for 1-2 hours and restart VS Code. You should still be signed in

## 🔗 Related issue

Closes: #500