### PR TITLE
Update actions used in GH workflows to latest. Closes #742

### DIFF
--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout SPFx Toolkit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: vscode-viva
         

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -15,13 +15,13 @@ jobs:
     
     steps:
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout vscode-viva
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: vscode-viva
         

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -18,8 +18,8 @@ jobs:
       pages: read
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
 

--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout vscode-viva
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: vscode-viva
         

--- a/.github/workflows/release-open-vsx.yml
+++ b/.github/workflows/release-open-vsx.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout vscode-viva
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: vscode-viva
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout vscode-viva
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: vscode-viva
         

--- a/.github/workflows/update-samples.yml
+++ b/.github/workflows/update-samples.yml
@@ -61,14 +61,26 @@ jobs:
           Remove-Item sample-stats.txt
         shell: pwsh
 
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b update-sample-data
+          git add -A
+          git diff --quiet && git diff --staged --quiet || git commit -m "Updates sample data"
+          git push origin update-sample-data --force
+        shell: pwsh
+
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
-        with:
-          commit-message: Updates sample data
-          branch: update-sample-data
-          title: Sample data update
-          body: |
-            Automated check and update of SPFx extensions and webparts samples data and aces sample data.
-            
-            ${{ steps.stats.outputs.STATS }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $prBody = @"
+          Automated check and update of SPFx extensions and webparts samples data and aces sample data.
+          
+          ${{ steps.stats.outputs.STATS }}
+          "@
+          
+          gh pr create --title "Sample data update" --body $prBody --base main --head update-sample-data || gh pr edit update-sample-data --body $prBody
+        shell: pwsh
 ...

--- a/.github/workflows/update-samples.yml
+++ b/.github/workflows/update-samples.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update:
-    # if: github.repository_owner == 'pnp'
+    if: github.repository_owner == 'pnp'
     name: "Update samples json"
     runs-on: windows-latest
 

--- a/.github/workflows/update-samples.yml
+++ b/.github/workflows/update-samples.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update:
-    if: github.repository_owner == 'pnp'
+    # if: github.repository_owner == 'pnp'
     name: "Update samples json"
     runs-on: windows-latest
 
@@ -17,28 +17,28 @@ jobs:
     
     steps:
       - name: Checkout vscode-viva
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout sp-dev-fx-aces
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: pnp/sp-dev-fx-aces
           path: sp-dev-fx-aces
 
       - name: Checkout sp-dev-fx-extensions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: pnp/sp-dev-fx-extensions
           path: sp-dev-fx-extensions
 
       - name: Checkout sp-dev-fx-library-components
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: pnp/sp-dev-fx-library-components
           path: sp-dev-fx-library-components
 
       - name: Checkout sp-dev-fx-webparts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: pnp/sp-dev-fx-webparts
           path: sp-dev-fx-webparts


### PR DESCRIPTION
## 🎯 Aim

> This PR fixes the Node.js 20 deprecation warnings by updating all workflow files to use the latest action versions that support Node.js 24. peter-evans/create-pull-request@v5 isn't updated to support Node 24 yet so replace that with native GitHub CLI commands.

## 📷 Result

> <img width="1170" height="1000" alt="image" src="https://github.com/user-attachments/assets/699bb549-3908-4790-8675-2b7936cfbe3d" />


## ✅ What was done

- [X] Updated all workflows to support Node.js 24

## 🔗 Related issue

Closes: #742 