### PR TITLE
Adds SPFx workbench extension link. Closes #756

### DIFF
--- a/src/panels/HelpTreeData.ts
+++ b/src/panels/HelpTreeData.ts
@@ -15,6 +15,7 @@ export const helpCommands: ActionTreeItem[] = [
     new ActionTreeItem('Resources & Tooling', '', undefined, TreeItemCollapsibleState.Expanded, undefined, undefined, undefined, [
         new ActionTreeItem('Microsoft Graph Explorer', '', { name: 'globe', custom: false }, undefined, 'vscode.open', Uri.parse('https://developer.microsoft.com/en-us/graph/graph-explorer')),
         new ActionTreeItem('Microsoft 365 Agents Toolkit', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension')),
+        new ActionTreeItem('SPFx Local Workbench', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=theChrisKent.spfx-local-workbench')),
         new ActionTreeItem('Adaptive Card Previewer', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.vscode-adaptive-cards')),
         new ActionTreeItem('CLI for Microsoft 365 MCP server', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://github.com/pnp/cli-microsoft365-mcp-server')),
         new ActionTreeItem('SharePoint Embedded', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=SharepointEmbedded.ms-sharepoint-embedded-vscode-extension')),

--- a/src/test/suite/helpView.test.ts
+++ b/src/test/suite/helpView.test.ts
@@ -72,6 +72,7 @@ suite('Help and feedback', () => {
         const expectedItems = [
             'Microsoft Graph Explorer',
             'Microsoft 365 Agents Toolkit',
+            'SPFx Local Workbench',
             'Adaptive Card Previewer',
             'CLI for Microsoft 365 MCP server',
             'SharePoint Embedded',
@@ -172,6 +173,10 @@ suite('Help and feedback', () => {
             {
                 label: 'Microsoft 365 Agents Toolkit',
                 url: 'https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension'
+            },
+            {
+                label: 'SPFx Local Workbench',
+                url: 'https://marketplace.visualstudio.com/items?itemName=theChrisKent.spfx-local-workbench'
             },
             {
                 label: 'CLI for Microsoft 365 MCP server',


### PR DESCRIPTION
## 🎯 Aim

The aim is to add a link to SPFx Workbench VS Code extension in the help and feedback tooling section

## 🔗 Related issue

Closes #756