### PR TITLE
Adds shortcut for the extension. Closes #732

### DIFF
--- a/package.json
+++ b/package.json
@@ -961,6 +961,14 @@
 				}
 			]
 		},
+		"keybindings": [
+      {
+        "command": "workbench.view.extension.pnp-view",
+        "key": "ctrl+alt+s",
+        "mac": "cmd+alt+s",
+        "when": "true"
+      }
+    ],
 		"views": {
 			"pnp-view": [
 				{


### PR DESCRIPTION
## 🎯 Aim

Adds a shortcut that will allow you to quickly jump to the extension activity view

## 📷 Result

<img width="527" height="478" alt="{3E4419CE-75D1-486D-A7BF-DA9B70CF56EA}" src="https://github.com/user-attachments/assets/4d02001a-d1ed-4a07-ab20-6a0dd2e5a021" />

## 🔗 Related issue

Closes: #732