### PR TITLE
Adds status bar SPFx indicator. Closes #698

### DIFF
--- a/src/constants/Commands.ts
+++ b/src/constants/Commands.ts
@@ -75,6 +75,9 @@ export const Commands = {
   refreshAppCatalogTreeView: `${EXTENSION_NAME}.refreshAppCatalogTreeView`,
   refreshAccountTreeView: `${EXTENSION_NAME}.refreshAccountTreeView`,
 
+  // Status bar
+  refreshSpfxProjectStatus: `${EXTENSION_NAME}.refreshSpfxProjectStatus`,
+
   // Welcome
   welcome: `${EXTENSION_NAME}.welcome`,
 

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -1,4 +1,4 @@
-import { commands, workspace, window, Uri, TreeItemCollapsibleState } from 'vscode';
+import { commands, workspace, window, Uri, TreeItemCollapsibleState, StatusBarAlignment } from 'vscode';
 import { Commands, ContextKeys } from '../constants';
 import { ActionTreeItem, ActionTreeDataProvider } from '../providers/ActionTreeDataProvider';
 import { AuthProvider, M365AuthenticationSession } from '../providers/AuthProvider';
@@ -7,18 +7,36 @@ import { DebuggerCheck } from '../services/check/DebuggerCheck';
 import { EnvironmentInformation } from '../services/dataType/EnvironmentInformation';
 import { M365AgentsToolkitIntegration } from '../services/dataType/M365AgentsToolkitIntegration';
 import { ProjectInformation } from '../services/dataType/ProjectInformation';
+import { buildSPFxStatusBarTooltip } from '../services/check/SpfxStatusTooltip';
 import { Subscription } from '../models';
 import { Extension } from '../services/dataType/Extension';
-import { getExtensionSettings, parsePackageJson, parseYoRc } from '../utils';
+import { getExtensionSettings, getVersion, parsePackageJson, parseYoRc } from '../utils';
 import { Notifications } from '../services/dataType/Notifications';
 import { helpCommands } from './HelpTreeData';
 import { getCombinedTaskCommands } from './TaskTreeData';
 
 
 export class CommandPanel {
+  private static readonly refreshSpfxStatusCommand = 'spfx-toolkit.refreshSpfxProjectStatus';
+  private static statusBarItem = window.createStatusBarItem('pnp.spfx.projectStatus', StatusBarAlignment.Left, 100);
 
   public static register() {
     const subscriptions: Subscription[] = Extension.getInstance().subscriptions;
+
+    subscriptions.push(CommandPanel.statusBarItem);
+    subscriptions.push(
+      commands.registerCommand(CommandPanel.refreshSpfxStatusCommand, async () => {
+        await CommandPanel.refreshProjectContext();
+      })
+    );
+    subscriptions.push(workspace.onDidChangeWorkspaceFolders(() => {
+      CommandPanel.refreshProjectContext();
+    }));
+    subscriptions.push(workspace.onDidSaveTextDocument((document) => {
+      if (document.fileName.endsWith('.yo-rc.json') || document.fileName.endsWith('package.json')) {
+        CommandPanel.refreshProjectContext();
+      }
+    }));
 
     subscriptions.push(
       commands.registerCommand(Commands.refreshAppCatalogTreeView, CommandPanel.refreshEnvironmentTreeView)
@@ -34,6 +52,13 @@ export class CommandPanel {
   }
 
   private static async init() {
+    await CommandPanel.refreshProjectContext();
+
+    await CommandPanel.registerTreeView();
+    AuthProvider.verify();
+  }
+
+  private static async refreshProjectContext() {
     try {
       const isM365AgentsToolkitProject = await CommandPanel.isM365AgentsToolkitProject();
       const isSPFxProject = isM365AgentsToolkitProject ? true : await CommandPanel.isSPFxProject();
@@ -42,15 +67,30 @@ export class CommandPanel {
       ProjectInformation.isSPFxProject = isSPFxProject;
       M365AgentsToolkitIntegration.isM365AgentsToolkitProject = isM365AgentsToolkitProject;
 
-      await CommandPanel.registerTreeView();
-      AuthProvider.verify();
+      await CommandPanel.updateSPFxStatusBarItem(isSPFxProject);
 
     } catch (error) {
       commands.executeCommand('setContext', ContextKeys.isSPFxProject, false);
       ProjectInformation.isSPFxProject = false;
       M365AgentsToolkitIntegration.isM365AgentsToolkitProject = false;
+      CommandPanel.statusBarItem.hide();
       Notifications.error('Error initializing the extension, please verify the project and try again.');
     }
+  }
+
+  private static async updateSPFxStatusBarItem(isSPFxProject: boolean) {
+    if (!isSPFxProject) {
+      CommandPanel.statusBarItem.hide();
+      return;
+    }
+
+    const version = await getVersion();
+    const status = await buildSPFxStatusBarTooltip(version);
+
+    CommandPanel.statusBarItem.text = `${status.hasCompatibilityIssues ? '$(warning)' : ''} SPFx ${version ?? ''}`.trim();
+    CommandPanel.statusBarItem.tooltip = status.tooltip;
+    CommandPanel.statusBarItem.command = CommandPanel.refreshSpfxStatusCommand;
+    CommandPanel.statusBarItem.show();
   }
 
   private static async registerTasksTreeView() {

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { commands, workspace, window, Uri, TreeItemCollapsibleState, StatusBarAlignment } from 'vscode';
 import { Commands, ContextKeys } from '../constants';
 import { ActionTreeItem, ActionTreeDataProvider } from '../providers/ActionTreeDataProvider';
@@ -17,7 +18,6 @@ import { getCombinedTaskCommands } from './TaskTreeData';
 
 
 export class CommandPanel {
-  private static readonly refreshSpfxStatusCommand = 'spfx-toolkit.refreshSpfxProjectStatus';
   private static statusBarItem = window.createStatusBarItem('pnp.spfx.projectStatus', StatusBarAlignment.Left, 100);
 
   public static register() {
@@ -25,7 +25,7 @@ export class CommandPanel {
 
     subscriptions.push(CommandPanel.statusBarItem);
     subscriptions.push(
-      commands.registerCommand(CommandPanel.refreshSpfxStatusCommand, async () => {
+      commands.registerCommand(Commands.refreshSpfxProjectStatus, async () => {
         await CommandPanel.refreshProjectContext();
       })
     );
@@ -33,7 +33,7 @@ export class CommandPanel {
       CommandPanel.refreshProjectContext();
     }));
     subscriptions.push(workspace.onDidSaveTextDocument((document) => {
-      if (document.fileName.endsWith('.yo-rc.json') || document.fileName.endsWith('package.json')) {
+      if (CommandPanel.isProjectManifestFile(document.fileName)) {
         CommandPanel.refreshProjectContext();
       }
     }));
@@ -89,8 +89,27 @@ export class CommandPanel {
 
     CommandPanel.statusBarItem.text = `${status.hasCompatibilityIssues ? '$(warning)' : ''} SPFx ${version ?? ''}`.trim();
     CommandPanel.statusBarItem.tooltip = status.tooltip;
-    CommandPanel.statusBarItem.command = CommandPanel.refreshSpfxStatusCommand;
+    CommandPanel.statusBarItem.command = Commands.refreshSpfxProjectStatus;
     CommandPanel.statusBarItem.show();
+  }
+
+  private static isProjectManifestFile(fileName: string): boolean {
+    const baseName = path.basename(fileName);
+    if (baseName !== '.yo-rc.json' && baseName !== 'package.json') {
+      return false;
+    }
+
+    const folders = workspace.workspaceFolders;
+    if (!folders || folders.length === 0) {
+      return false;
+    }
+
+    const normalized = path.normalize(fileName);
+    return folders.some(folder => {
+      const root = folder.uri.fsPath;
+      return normalized === path.join(root, baseName) ||
+             normalized === path.join(root, 'src', baseName);
+    });
   }
 
   private static async registerTasksTreeView() {

--- a/src/services/check/SpfxStatusTooltip.ts
+++ b/src/services/check/SpfxStatusTooltip.ts
@@ -1,0 +1,50 @@
+import { SpfxCompatibilityMatrix } from '../../constants';
+import { Dependencies } from '../actions/Dependencies';
+import { MarkdownString } from 'vscode';
+
+
+export interface SpfxStatusBarTooltip {
+  tooltip: MarkdownString;
+  hasCompatibilityIssues: boolean;
+}
+
+export const buildSPFxStatusBarTooltip = async (spfxVersion: string | undefined): Promise<SpfxStatusBarTooltip> => {
+  if (!spfxVersion) {
+    return {
+      tooltip: createTooltip('SharePoint Framework project\n\nVersion could not be resolved from .yo-rc.json or package.json.'),
+      hasCompatibilityIssues: true
+    };
+  }
+
+  const compatibility = SpfxCompatibilityMatrix.find(item => item.Version === spfxVersion);
+  if (!compatibility) {
+    return {
+      tooltip: createTooltip(`SharePoint Framework project v${spfxVersion}\n\nCompatibility matrix entry not found for this version.`),
+      hasCompatibilityIssues: true
+    };
+  }
+
+  const nodeVersion = Dependencies.getCurrentNodeVersion();
+  const isNodeSupported = Dependencies.isValidNodeJs(compatibility.SupportedNodeVersions, nodeVersion);
+
+  const hasCompatibilityIssues = !isNodeSupported;
+
+  const nodeExpected = compatibility.SupportedNodeVersions.join(' | ');
+  const nodeLine = `${isNodeSupported ? '$(check)' : '$(close)'} Node.js: ${nodeVersion ?? 'not found'} (expected: ${nodeExpected})`;
+
+  const lines: string[] = [
+    `SPFx v${spfxVersion} compatibility:`,
+    nodeLine
+  ];
+
+  return {
+    tooltip: createTooltip(lines.join('\n\n')),
+    hasCompatibilityIssues
+  };
+};
+
+const createTooltip = (text: string): MarkdownString => {
+  const tooltip = new MarkdownString(text, true);
+  tooltip.isTrusted = false;
+  return tooltip;
+};


### PR DESCRIPTION
## 🎯 Aim

The aim is to add SPFx status bar indicator 

## 📷 Result

When node is NOT compatible with the current project SPFx version
<img width="627" height="818" alt="image" src="https://github.com/user-attachments/assets/fac99df4-0e2b-4657-9f73-82eb89653e82" />

When Node is compatible with the current project SPFx version
<img width="875" height="820" alt="image" src="https://github.com/user-attachments/assets/b89fc187-11a2-4048-9200-f62551491127" />


## ✅ What was done

- [X] Added status indicator
- [X] Added node check in status indicator
- [X] Added refresh on click

## 🔗 Related issue

Closes: #698