### PR TITLE
Adds support for SPFx 1.23.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@grconrad/vscode-extension-feedback": "^1.0.0",
-				"@pnp/cli-microsoft365-spfx-toolkit": "1.10.0",
+				"@pnp/cli-microsoft365-spfx-toolkit": "1.11.0",
 				"node-forge": "1.4.0",
 				"react-markdown": "10.1.0",
 				"rehype-raw": "7.0.0",
@@ -858,9 +858,9 @@
 			}
 		},
 		"node_modules/@pnp/cli-microsoft365-spfx-toolkit": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365-spfx-toolkit/-/cli-microsoft365-spfx-toolkit-1.10.0.tgz",
-			"integrity": "sha512-Db0BpjAF6Q76UWsjpTcCuMRf4xHJqYvwKb93oQKQsoUyLy5GixPK89S7Z9RVWmRS+b66DDIY4ohvyJ1aJeKDWA==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365-spfx-toolkit/-/cli-microsoft365-spfx-toolkit-1.11.0.tgz",
+			"integrity": "sha512-YMjLH3D+7zowLMjJlB5UCRe8SJPkYyhpWx1ok8CobnAjhH0xvo3Yryt1UKIaQUOi76tQGOe+9WWpCWpInxAlbA==",
 			"hasShrinkwrap": true,
 			"license": "MIT",
 			"dependencies": {
@@ -872,7 +872,7 @@
 				"adaptivecards-templating": "^2.3.1",
 				"adm-zip": "^0.5.10",
 				"applicationinsights": "^2.9.8",
-				"axios": "^0.30.2",
+				"axios": "0.30.2",
 				"chalk": "^4.1.2",
 				"clipboardy": "^2.3.0",
 				"csv-stringify": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1618,7 +1618,7 @@
 	},
 	"dependencies": {
 		"@grconrad/vscode-extension-feedback": "^1.0.0",
-		"@pnp/cli-microsoft365-spfx-toolkit": "1.10.0",
+		"@pnp/cli-microsoft365-spfx-toolkit": "1.11.0",
 		"node-forge": "1.4.0",
 		"react-markdown": "10.1.0",
 		"remark-gfm": "4.0.1",

--- a/src/constants/SpfxCompatibilityMatrix.ts
+++ b/src/constants/SpfxCompatibilityMatrix.ts
@@ -2,6 +2,23 @@ import { CompatibilityItem } from '../models';
 
 export const SpfxCompatibilityMatrix: CompatibilityItem[] = [
     {
+        Version: '1.23.0',
+        SupportedNodeVersions: ['22.14.x'],
+        ReleaseNotes: 'https://learn.microsoft.com/en-us/sharepoint/dev/spfx/release-1.23.0',
+        Dependencies: [
+            {
+                Name: '@rushstack/heft',
+                SupportedVersions: ['1.x'],
+                InstallVersion: 'latest'
+            },
+            {
+                Name: 'yo',
+                SupportedVersions: ['4.x', '5.x', '6.x', '7.x'],
+                InstallVersion: '7'
+            }
+        ]
+    },
+    {
         Version: '1.22.2',
         SupportedNodeVersions: ['22.14.x'],
         ReleaseNotes: 'https://learn.microsoft.com/en-us/sharepoint/dev/spfx/release-1.22.2',


### PR DESCRIPTION
## 🎯 Aim

The aim is to add support for SPFx 1.23.0

## 📷 Result

<img width="964" height="578" alt="{60331F34-C9CE-43A2-9CAA-0EDD1E21D199}" src="https://github.com/user-attachments/assets/94fbc58b-55f1-4c66-847a-87c25f3c118d" />

<img width="1509" height="358" alt="{EF5ECA00-28CF-457D-8D62-2572431BD097}" src="https://github.com/user-attachments/assets/bb8b132b-2399-4dc5-aad0-05b2c8704f94" />

<img width="396" height="184" alt="{27DD133B-ABF8-48D8-AC19-A11CC131CF61}" src="https://github.com/user-attachments/assets/4a8237b9-3f82-44a2-950d-6083b3ae2563" />

<img width="1746" height="1019" alt="{0EA85054-CB5B-4A85-9054-E3BE3833DEE2}" src="https://github.com/user-attachments/assets/3f8e1ffb-64d7-4e0b-bf17-160a9e2f8089" />

## ✅ What was done

- [X] Extended compatibility matrix
- [X] Updated to the latest version of CLI for Microsoft 365 for SPFx Toolkit
