### PR TITLE
Release v4.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [4.19.0] - 2026-05-22
+
+- Added support for SPFx 1.23
+- Added status bar SPFx indicator
+- Added shortcut for the extension
+- Added SPFx workbench extension link
+
 ## [4.18.0] - 2026-04-01
 
 - Updated the way SPFx Toolkit handles token refresh, which extends the time the user is signed in to SharePoint Online tenant

--- a/docs/src/content/docs/about/changelog.mdx
+++ b/docs/src/content/docs/about/changelog.mdx
@@ -2,6 +2,13 @@
 title: Changelog
 ---
 
+## [4.19.0] - 2026-05-22
+
+- Added support for SPFx 1.23
+- Added status bar SPFx indicator
+- Added shortcut for the extension
+- Added SPFx workbench extension link
+
 ## [4.18.0] - 2026-04-01
 
 - Updated the way SPFx Toolkit handles token refresh, which extends the time the user is signed in to SharePoint Online tenant

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
 	"name": "viva-connections-toolkit",
-	"version": "4.18.0",
+	"version": "4.18.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "viva-connections-toolkit",
-			"version": "4.18.0",
+			"version": "4.18.1",
 			"license": "MIT",
 			"dependencies": {
 				"@grconrad/vscode-extension-feedback": "^1.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
 	"name": "viva-connections-toolkit",
-	"version": "4.18.2",
+	"version": "4.18.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "viva-connections-toolkit",
-			"version": "4.18.2",
+			"version": "4.18.3",
 			"license": "MIT",
 			"dependencies": {
 				"@grconrad/vscode-extension-feedback": "^1.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
 	"name": "viva-connections-toolkit",
-	"version": "4.18.1",
+	"version": "4.18.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "viva-connections-toolkit",
-			"version": "4.18.1",
+			"version": "4.18.2",
 			"license": "MIT",
 			"dependencies": {
 				"@grconrad/vscode-extension-feedback": "^1.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
 	"name": "viva-connections-toolkit",
-	"version": "4.18.3",
+	"version": "4.19.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "viva-connections-toolkit",
-			"version": "4.18.3",
+			"version": "4.19.0",
 			"license": "MIT",
 			"dependencies": {
 				"@grconrad/vscode-extension-feedback": "^1.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@grconrad/vscode-extension-feedback": "^1.0.0",
-				"@pnp/cli-microsoft365-spfx-toolkit": "1.10.0",
+				"@pnp/cli-microsoft365-spfx-toolkit": "1.11.0",
 				"node-forge": "1.4.0",
 				"react-markdown": "10.1.0",
 				"rehype-raw": "7.0.0",
@@ -858,9 +858,9 @@
 			}
 		},
 		"node_modules/@pnp/cli-microsoft365-spfx-toolkit": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365-spfx-toolkit/-/cli-microsoft365-spfx-toolkit-1.10.0.tgz",
-			"integrity": "sha512-Db0BpjAF6Q76UWsjpTcCuMRf4xHJqYvwKb93oQKQsoUyLy5GixPK89S7Z9RVWmRS+b66DDIY4ohvyJ1aJeKDWA==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365-spfx-toolkit/-/cli-microsoft365-spfx-toolkit-1.11.0.tgz",
+			"integrity": "sha512-YMjLH3D+7zowLMjJlB5UCRe8SJPkYyhpWx1ok8CobnAjhH0xvo3Yryt1UKIaQUOi76tQGOe+9WWpCWpInxAlbA==",
 			"hasShrinkwrap": true,
 			"license": "MIT",
 			"dependencies": {
@@ -872,7 +872,7 @@
 				"adaptivecards-templating": "^2.3.1",
 				"adm-zip": "^0.5.10",
 				"applicationinsights": "^2.9.8",
-				"axios": "^0.30.2",
+				"axios": "0.30.2",
 				"chalk": "^4.1.2",
 				"clipboardy": "^2.3.0",
 				"csv-stringify": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -961,6 +961,14 @@
 				}
 			]
 		},
+		"keybindings": [
+      {
+        "command": "workbench.view.extension.pnp-view",
+        "key": "ctrl+alt+s",
+        "mac": "cmd+alt+s",
+        "when": "true"
+      }
+    ],
 		"views": {
 			"pnp-view": [
 				{

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "viva-connections-toolkit",
 	"displayName": "SharePoint Framework Toolkit",
 	"description": "SharePoint Framework Toolkit aims to boost your productivity in developing and managing SharePoint Framework solutions helping at every stage of your development flow, from setting up your development workspace to deploying a solution straight to your tenant without the need to leave VS Code and now even create a CI/CD pipeline to introduce automate deployment of your app. This toolkit is provided by the community.",
-	"version": "4.18.0",
+	"version": "4.18.1",
 	"publisher": "m365pnp",
 	"preview": false,
 	"homepage": "https://pnp.github.io/vscode-viva",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "viva-connections-toolkit",
 	"displayName": "SharePoint Framework Toolkit",
 	"description": "SharePoint Framework Toolkit aims to boost your productivity in developing and managing SharePoint Framework solutions helping at every stage of your development flow, from setting up your development workspace to deploying a solution straight to your tenant without the need to leave VS Code and now even create a CI/CD pipeline to introduce automate deployment of your app. This toolkit is provided by the community.",
-	"version": "4.18.2",
+	"version": "4.18.3",
 	"publisher": "m365pnp",
 	"preview": false,
 	"homepage": "https://pnp.github.io/vscode-viva",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "viva-connections-toolkit",
 	"displayName": "SharePoint Framework Toolkit",
 	"description": "SharePoint Framework Toolkit aims to boost your productivity in developing and managing SharePoint Framework solutions helping at every stage of your development flow, from setting up your development workspace to deploying a solution straight to your tenant without the need to leave VS Code and now even create a CI/CD pipeline to introduce automate deployment of your app. This toolkit is provided by the community.",
-	"version": "4.18.3",
+	"version": "4.19.0",
 	"publisher": "m365pnp",
 	"preview": false,
 	"homepage": "https://pnp.github.io/vscode-viva",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "viva-connections-toolkit",
 	"displayName": "SharePoint Framework Toolkit",
 	"description": "SharePoint Framework Toolkit aims to boost your productivity in developing and managing SharePoint Framework solutions helping at every stage of your development flow, from setting up your development workspace to deploying a solution straight to your tenant without the need to leave VS Code and now even create a CI/CD pipeline to introduce automate deployment of your app. This toolkit is provided by the community.",
-	"version": "4.18.1",
+	"version": "4.18.2",
 	"publisher": "m365pnp",
 	"preview": false,
 	"homepage": "https://pnp.github.io/vscode-viva",

--- a/package.json
+++ b/package.json
@@ -1618,7 +1618,7 @@
 	},
 	"dependencies": {
 		"@grconrad/vscode-extension-feedback": "^1.0.0",
-		"@pnp/cli-microsoft365-spfx-toolkit": "1.10.0",
+		"@pnp/cli-microsoft365-spfx-toolkit": "1.11.0",
 		"node-forge": "1.4.0",
 		"react-markdown": "10.1.0",
 		"remark-gfm": "4.0.1",

--- a/src/constants/Commands.ts
+++ b/src/constants/Commands.ts
@@ -75,6 +75,9 @@ export const Commands = {
   refreshAppCatalogTreeView: `${EXTENSION_NAME}.refreshAppCatalogTreeView`,
   refreshAccountTreeView: `${EXTENSION_NAME}.refreshAccountTreeView`,
 
+  // Status bar
+  refreshSpfxProjectStatus: `${EXTENSION_NAME}.refreshSpfxProjectStatus`,
+
   // Welcome
   welcome: `${EXTENSION_NAME}.welcome`,
 

--- a/src/constants/SpfxCompatibilityMatrix.ts
+++ b/src/constants/SpfxCompatibilityMatrix.ts
@@ -2,6 +2,23 @@ import { CompatibilityItem } from '../models';
 
 export const SpfxCompatibilityMatrix: CompatibilityItem[] = [
     {
+        Version: '1.23.0',
+        SupportedNodeVersions: ['22.14.x'],
+        ReleaseNotes: 'https://learn.microsoft.com/en-us/sharepoint/dev/spfx/release-1.23.0',
+        Dependencies: [
+            {
+                Name: '@rushstack/heft',
+                SupportedVersions: ['1.x'],
+                InstallVersion: 'latest'
+            },
+            {
+                Name: 'yo',
+                SupportedVersions: ['4.x', '5.x', '6.x', '7.x'],
+                InstallVersion: '7'
+            }
+        ]
+    },
+    {
         Version: '1.22.2',
         SupportedNodeVersions: ['22.14.x'],
         ReleaseNotes: 'https://learn.microsoft.com/en-us/sharepoint/dev/spfx/release-1.22.2',

--- a/src/panels/CommandPanel.ts
+++ b/src/panels/CommandPanel.ts
@@ -1,4 +1,5 @@
-import { commands, workspace, window, Uri, TreeItemCollapsibleState } from 'vscode';
+import * as path from 'path';
+import { commands, workspace, window, Uri, TreeItemCollapsibleState, StatusBarAlignment } from 'vscode';
 import { Commands, ContextKeys } from '../constants';
 import { ActionTreeItem, ActionTreeDataProvider } from '../providers/ActionTreeDataProvider';
 import { AuthProvider, M365AuthenticationSession } from '../providers/AuthProvider';
@@ -7,18 +8,35 @@ import { DebuggerCheck } from '../services/check/DebuggerCheck';
 import { EnvironmentInformation } from '../services/dataType/EnvironmentInformation';
 import { M365AgentsToolkitIntegration } from '../services/dataType/M365AgentsToolkitIntegration';
 import { ProjectInformation } from '../services/dataType/ProjectInformation';
+import { buildSPFxStatusBarTooltip } from '../services/check/SpfxStatusTooltip';
 import { Subscription } from '../models';
 import { Extension } from '../services/dataType/Extension';
-import { getExtensionSettings, parsePackageJson, parseYoRc } from '../utils';
+import { getExtensionSettings, getVersion, parsePackageJson, parseYoRc } from '../utils';
 import { Notifications } from '../services/dataType/Notifications';
 import { helpCommands } from './HelpTreeData';
 import { getCombinedTaskCommands } from './TaskTreeData';
 
 
 export class CommandPanel {
+  private static statusBarItem = window.createStatusBarItem('pnp.spfx.projectStatus', StatusBarAlignment.Left, 100);
 
   public static register() {
     const subscriptions: Subscription[] = Extension.getInstance().subscriptions;
+
+    subscriptions.push(CommandPanel.statusBarItem);
+    subscriptions.push(
+      commands.registerCommand(Commands.refreshSpfxProjectStatus, async () => {
+        await CommandPanel.refreshProjectContext();
+      })
+    );
+    subscriptions.push(workspace.onDidChangeWorkspaceFolders(() => {
+      CommandPanel.refreshProjectContext();
+    }));
+    subscriptions.push(workspace.onDidSaveTextDocument((document) => {
+      if (CommandPanel.isProjectManifestFile(document.fileName)) {
+        CommandPanel.refreshProjectContext();
+      }
+    }));
 
     subscriptions.push(
       commands.registerCommand(Commands.refreshAppCatalogTreeView, CommandPanel.refreshEnvironmentTreeView)
@@ -34,6 +52,13 @@ export class CommandPanel {
   }
 
   private static async init() {
+    await CommandPanel.refreshProjectContext();
+
+    await CommandPanel.registerTreeView();
+    AuthProvider.verify();
+  }
+
+  private static async refreshProjectContext() {
     try {
       const isM365AgentsToolkitProject = await CommandPanel.isM365AgentsToolkitProject();
       const isSPFxProject = isM365AgentsToolkitProject ? true : await CommandPanel.isSPFxProject();
@@ -42,15 +67,49 @@ export class CommandPanel {
       ProjectInformation.isSPFxProject = isSPFxProject;
       M365AgentsToolkitIntegration.isM365AgentsToolkitProject = isM365AgentsToolkitProject;
 
-      await CommandPanel.registerTreeView();
-      AuthProvider.verify();
+      await CommandPanel.updateSPFxStatusBarItem(isSPFxProject);
 
     } catch (error) {
       commands.executeCommand('setContext', ContextKeys.isSPFxProject, false);
       ProjectInformation.isSPFxProject = false;
       M365AgentsToolkitIntegration.isM365AgentsToolkitProject = false;
+      CommandPanel.statusBarItem.hide();
       Notifications.error('Error initializing the extension, please verify the project and try again.');
     }
+  }
+
+  private static async updateSPFxStatusBarItem(isSPFxProject: boolean) {
+    if (!isSPFxProject) {
+      CommandPanel.statusBarItem.hide();
+      return;
+    }
+
+    const version = await getVersion();
+    const status = await buildSPFxStatusBarTooltip(version);
+
+    CommandPanel.statusBarItem.text = `${status.hasCompatibilityIssues ? '$(warning)' : ''} SPFx ${version ?? ''}`.trim();
+    CommandPanel.statusBarItem.tooltip = status.tooltip;
+    CommandPanel.statusBarItem.command = Commands.refreshSpfxProjectStatus;
+    CommandPanel.statusBarItem.show();
+  }
+
+  private static isProjectManifestFile(fileName: string): boolean {
+    const baseName = path.basename(fileName);
+    if (baseName !== '.yo-rc.json' && baseName !== 'package.json') {
+      return false;
+    }
+
+    const folders = workspace.workspaceFolders;
+    if (!folders || folders.length === 0) {
+      return false;
+    }
+
+    const normalized = path.normalize(fileName);
+    return folders.some(folder => {
+      const root = folder.uri.fsPath;
+      return normalized === path.join(root, baseName) ||
+             normalized === path.join(root, 'src', baseName);
+    });
   }
 
   private static async registerTasksTreeView() {

--- a/src/panels/HelpTreeData.ts
+++ b/src/panels/HelpTreeData.ts
@@ -15,6 +15,7 @@ export const helpCommands: ActionTreeItem[] = [
     new ActionTreeItem('Resources & Tooling', '', undefined, TreeItemCollapsibleState.Expanded, undefined, undefined, undefined, [
         new ActionTreeItem('Microsoft Graph Explorer', '', { name: 'globe', custom: false }, undefined, 'vscode.open', Uri.parse('https://developer.microsoft.com/en-us/graph/graph-explorer')),
         new ActionTreeItem('Microsoft 365 Agents Toolkit', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension')),
+        new ActionTreeItem('SPFx Local Workbench', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=theChrisKent.spfx-local-workbench')),
         new ActionTreeItem('Adaptive Card Previewer', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.vscode-adaptive-cards')),
         new ActionTreeItem('CLI for Microsoft 365 MCP server', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://github.com/pnp/cli-microsoft365-mcp-server')),
         new ActionTreeItem('SharePoint Embedded', '', { name: 'tools', custom: false }, undefined, 'vscode.open', Uri.parse('https://marketplace.visualstudio.com/items?itemName=SharepointEmbedded.ms-sharepoint-embedded-vscode-extension')),

--- a/src/services/check/SpfxStatusTooltip.ts
+++ b/src/services/check/SpfxStatusTooltip.ts
@@ -1,0 +1,50 @@
+import { SpfxCompatibilityMatrix } from '../../constants';
+import { Dependencies } from '../actions/Dependencies';
+import { MarkdownString } from 'vscode';
+
+
+export interface SpfxStatusBarTooltip {
+  tooltip: MarkdownString;
+  hasCompatibilityIssues: boolean;
+}
+
+export const buildSPFxStatusBarTooltip = async (spfxVersion: string | undefined): Promise<SpfxStatusBarTooltip> => {
+  if (!spfxVersion) {
+    return {
+      tooltip: createTooltip('SharePoint Framework project\n\nVersion could not be resolved from .yo-rc.json or package.json.'),
+      hasCompatibilityIssues: true
+    };
+  }
+
+  const compatibility = SpfxCompatibilityMatrix.find(item => item.Version === spfxVersion);
+  if (!compatibility) {
+    return {
+      tooltip: createTooltip(`SharePoint Framework project v${spfxVersion}\n\nCompatibility matrix entry not found for this version.`),
+      hasCompatibilityIssues: true
+    };
+  }
+
+  const nodeVersion = Dependencies.getCurrentNodeVersion();
+  const isNodeSupported = Dependencies.isValidNodeJs(compatibility.SupportedNodeVersions, nodeVersion);
+
+  const hasCompatibilityIssues = !isNodeSupported;
+
+  const nodeExpected = compatibility.SupportedNodeVersions.join(' | ');
+  const nodeLine = `${isNodeSupported ? '$(check)' : '$(close)'} Node.js: ${nodeVersion ?? 'not found'} (expected: ${nodeExpected})`;
+
+  const lines: string[] = [
+    `SPFx v${spfxVersion} compatibility:`,
+    nodeLine
+  ];
+
+  return {
+    tooltip: createTooltip(lines.join('\n\n')),
+    hasCompatibilityIssues
+  };
+};
+
+const createTooltip = (text: string): MarkdownString => {
+  const tooltip = new MarkdownString(text, true);
+  tooltip.isTrusted = false;
+  return tooltip;
+};

--- a/src/test/suite/helpView.test.ts
+++ b/src/test/suite/helpView.test.ts
@@ -72,6 +72,7 @@ suite('Help and feedback', () => {
         const expectedItems = [
             'Microsoft Graph Explorer',
             'Microsoft 365 Agents Toolkit',
+            'SPFx Local Workbench',
             'Adaptive Card Previewer',
             'CLI for Microsoft 365 MCP server',
             'SharePoint Embedded',
@@ -172,6 +173,10 @@ suite('Help and feedback', () => {
             {
                 label: 'Microsoft 365 Agents Toolkit',
                 url: 'https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension'
+            },
+            {
+                label: 'SPFx Local Workbench',
+                url: 'https://marketplace.visualstudio.com/items?itemName=theChrisKent.spfx-local-workbench'
             },
             {
                 label: 'CLI for Microsoft 365 MCP server',


### PR DESCRIPTION
## 🎯 Aim

The aim of this PR is to perform a minor release of SPFx Toolkit, mainly to deliver support for SPFx 1.23

## 📷 Result

<img width="964" height="578"
alt="{60331F34-C9CE-43A2-9CAA-0EDD1E21D199}"
src="https://github.com/user-attachments/assets/94fbc58b-55f1-4c66-847a-87c25f3c118d"
/>

<img width="1509" height="358"
alt="{EF5ECA00-28CF-457D-8D62-2572431BD097}"
src="https://github.com/user-attachments/assets/bb8b132b-2399-4dc5-aad0-05b2c8704f94"
/>

<img width="396" height="184"
alt="{27DD133B-ABF8-48D8-AC19-A11CC131CF61}"
src="https://github.com/user-attachments/assets/4a8237b9-3f82-44a2-950d-6083b3ae2563"
/>

<img width="1746" height="1019"
alt="{0EA85054-CB5B-4A85-9054-E3BE3833DEE2}"
src="https://github.com/user-attachments/assets/3f8e1ffb-64d7-4e0b-bf17-160a9e2f8089"
/>

<img width="627" height="818" alt="image"
src="https://github.com/user-attachments/assets/fac99df4-0e2b-4657-9f73-82eb89653e82"
/>

When Node is compatible with the current project SPFx version
<img width="875" height="820" alt="image"
src="https://github.com/user-attachments/assets/b89fc187-11a2-4048-9200-f62551491127"
/>

## ✅ What was done

- [X] Adds support for SPFx 1.23
- [X] Adds status bar SPFx indicator
- [X] Adds shortcut for the extension
- [X] Adds SPFx workbench extension link