### PR TITLE
fix: remove hardcoded path in update-package-version script

### DIFF
--- a/scripts/update-package-version.ps1
+++ b/scripts/update-package-version.ps1
@@ -3,9 +3,9 @@ param (
     [string]$PathToWorkspace
 )
 
-$packageJson = Get-Content "$PathToWorkspace\vscode-viva\package.json" | ConvertFrom-Json
+$packageJson = Get-Content "$PathToWorkspace\package.json" | ConvertFrom-Json
 $oldVersion = $packageJson.version
 $oldVersionParts = $oldVersion.Split(".")
 $newVersion = "$($oldVersionParts[0]).$($oldVersionParts[1]).$([int]$oldVersionParts[2] + 1)"
 $packageJson.version = $newVersion
-$packageJson | ConvertTo-Json -Depth 10 | Out-File "$PathToWorkspace\vscode-viva\package.json" -Encoding utf8 -Force
+$packageJson | ConvertTo-Json -Depth 10 | Out-File "$PathToWorkspace\package.json" -Encoding utf8 -Force


### PR DESCRIPTION
## 🎯 Aim

Fixes the `update-package-version.ps1` script that had a hardcoded `\vscode-viva\` path causing the **Prepare pre-release** workflow to fail.
