### PR TITLE
Removes node cache from docs workflow. Closes #791

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -23,16 +23,7 @@ jobs:
         with:
           node-version: 22
 
-      - name: Cache node modules
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            **/docs/node_modules
-          key: docs_node_modules-${{ hashFiles('**/docs/package-lock.json') }}
-      
       - name: Install the dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
         working-directory: docs
 


### PR DESCRIPTION
## 🎯 Aim

The aim of this PR is to remove the use of node cache in our workflows as they do not prove safe. Currently we use it only in our release docs flow. Lets remove it and run `npm install` every time, this flow does not need to be fast, but safe

##  🔗 Related issue

Closes #791