### PR TITLE
Updates github workflows to increase security. Closes #791, #778, #772, #776

### DIFF
--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -2,6 +2,9 @@ name: Check Tests
 
 on: 
   pull_request:
+    branches:
+      - main
+      - dev
   workflow_dispatch:
 
 jobs:
@@ -9,24 +12,25 @@ jobs:
     if: github.repository_owner == 'pnp'
     name: "Test"
     runs-on: windows-latest
+    timeout-minutes: 40
 
     permissions:
       contents: read
 
     steps:
       - name: Setup node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout SPFx Toolkit
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: vscode-viva
         
       - name: Install dependencies for SPFx Toolkit
-        run: npm install --omit=optional
+        run: npm ci --ignore-scripts --omit=optional
         working-directory: vscode-viva
 
       - name: Build SPFx Toolkit

--- a/.github/workflows/prepare-release-beta.yml
+++ b/.github/workflows/prepare-release-beta.yml
@@ -8,6 +8,7 @@ jobs:
     if: github.repository_owner == 'pnp'
     name: "Prepares the pre-release"
     runs-on: windows-latest
+    timeout-minutes: 40
 
     permissions:
       contents: write
@@ -16,10 +17,10 @@ jobs:
     
     steps:
       - name: Checkout vscode-viva
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
@@ -30,7 +31,7 @@ jobs:
         continue-on-error: false
 
       - name: Verification - Install the dependencies
-        run: npm install --omit=optional
+        run: npm ci --ignore-scripts --omit=optional
 
       - name: Verification - Build
         run: npm run vscode:prepublish

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -8,6 +8,7 @@ jobs:
     if: github.repository_owner == 'pnp'
     name: "Build and pre-release"
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     permissions:
       contents: write
@@ -15,20 +16,24 @@ jobs:
     
     steps:
       - name: Setup node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout vscode-viva
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: vscode-viva
         
       - name: Install the dependencies
-        run: npm install --omit=optional
+        run: npm ci --ignore-scripts --omit=optional
+        working-directory: vscode-viva
+
+      - name: Install vsce
+        run: npm install --global --ignore-scripts @vscode/vsce@3.3.2
         working-directory: vscode-viva
 
       - name: Publish 
-        run: npx @vscode/vsce@3.3.2 publish -p ${{ secrets.VSCE_PAT }} --pre-release --baseImagesUrl https://raw.githubusercontent.com/pnp/vscode-viva/dev
+        run: vsce publish -p ${{ secrets.VSCE_PAT }} --pre-release --baseImagesUrl https://raw.githubusercontent.com/pnp/vscode-viva/dev
         working-directory: vscode-viva

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -13,27 +13,19 @@ jobs:
     if: github.repository_owner == 'pnp'
     name: "Build and release docs"
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     permissions:
       pages: read
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
 
-      - name: Cache node modules
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            **/docs/node_modules
-          key: docs_node_modules-${{ hashFiles('**/docs/package-lock.json') }}
-      
       - name: Install the dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: docs
 
       - name: Build docs
@@ -41,7 +33,7 @@ jobs:
         working-directory: docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: docs/dist
 
@@ -61,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -8,33 +8,37 @@ jobs:
     if: github.repository_owner == 'pnp'
     name: "Build and package"
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     permissions:
       contents: read
 
     steps:
       - name: Setup node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout vscode-viva
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: vscode-viva
         
       - name: Install the dependencies
-        run: npm install --omit=optional
+        run: npm ci --ignore-scripts --omit=optional
+        working-directory: vscode-viva
+
+      - name: Install vsce
+        run: npm install --global --ignore-scripts @vscode/vsce@3.3.2
         working-directory: vscode-viva
 
       - name: Package
-        run: |
-          npx @vscode/vsce@3.3.2 package
+        run: vsce package
         working-directory: vscode-viva
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: vsix_package
           path: |

--- a/.github/workflows/release-open-vsx.yml
+++ b/.github/workflows/release-open-vsx.yml
@@ -11,6 +11,7 @@ jobs:
     if: github.repository_owner == 'pnp'
     name: "Build and release"
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     permissions:
       contents: write
@@ -18,20 +19,24 @@ jobs:
 
     steps:
       - name: Setup node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout vscode-viva
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: vscode-viva
         
       - name: Install the dependencies
-        run: npm install --omit=optional
+        run: npm ci --ignore-scripts --omit=optional
+        working-directory: vscode-viva
+
+      - name: Install ovsx
+        run: npm install --global ovsx@0.10.9
         working-directory: vscode-viva
 
       - name: Publish
-        run: npx ovsx@0.10.9 publish -p ${{ secrets.OVSX_TOKEN }}
+        run: ovsx publish -p ${{ secrets.OVSX_TOKEN }}
         working-directory: vscode-viva

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     if: github.repository_owner == 'pnp'
     name: "Build and release"
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     permissions:
       contents: write
@@ -18,20 +19,24 @@ jobs:
 
     steps:
       - name: Setup node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       
       - name: Checkout vscode-viva
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: vscode-viva
         
       - name: Install the dependencies
-        run: npm install --omit=optional
+        run: npm ci --ignore-scripts --omit=optional
+        working-directory: vscode-viva
+
+      - name: Install vsce
+        run: npm install --global --ignore-scripts @vscode/vsce@3.3.2
         working-directory: vscode-viva
 
       - name: Publish
-        run: npx @vscode/vsce@3.3.2 publish -p ${{ secrets.VSCE_PAT }}
+        run: vsce publish -p ${{ secrets.VSCE_PAT }}
         working-directory: vscode-viva

--- a/.github/workflows/update-samples.yml
+++ b/.github/workflows/update-samples.yml
@@ -10,6 +10,7 @@ jobs:
     if: github.repository_owner == 'pnp'
     name: "Update samples json"
     runs-on: windows-latest
+    timeout-minutes: 40
 
     permissions:
       contents: write
@@ -17,28 +18,28 @@ jobs:
     
     steps:
       - name: Checkout vscode-viva
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Checkout sp-dev-fx-aces
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: pnp/sp-dev-fx-aces
           path: sp-dev-fx-aces
 
       - name: Checkout sp-dev-fx-extensions
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: pnp/sp-dev-fx-extensions
           path: sp-dev-fx-extensions
 
       - name: Checkout sp-dev-fx-library-components
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: pnp/sp-dev-fx-library-components
           path: sp-dev-fx-library-components
 
       - name: Checkout sp-dev-fx-webparts
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: pnp/sp-dev-fx-webparts
           path: sp-dev-fx-webparts

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4399,6 +4399,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "extraneous": true,
+      "optional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "os": [


### PR DESCRIPTION
## 🎯 Aim

The aim of this PR is to refactor and improve the security aspects of our GitHub workflows

## ✅ What was done

- [X] Switched to using `npm ci` instead of `npm install` to respect lockfiles; this prevents possible npm chain attacks
- [X] Added timeouts to all workflows
- [X] Disabled post-install scripts in all npm install commands
- [X] Dropped using `npx` 
- [X] Removed using any node cache
- [X] Pinned action SHAs — actions are now pinned to specific commit SHAs with the version in a comment for readability. This protects against supply chain attacks via tag mutation.

## 🔗 Related issue

Closes #791 #778 #772 #776