### PR TITLE
Customizes dependabot to add cooldown. Closes #773

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+updates:
+  # Monthly dependency updates
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+    groups:
+      update-dependencies:
+        patterns:
+          - "*"
+    versioning-strategy: increase
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 7
+
+  # Monthly docs dependency updates
+  - package-ecosystem: npm
+    directory: /docs
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+    groups:
+      update-dependencies:
+        patterns:
+          - "*"
+    versioning-strategy: increase
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 7
+
+  # Monthly GitHub Actions dependency updates
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      update-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## 🎯 Aim

The aim is to customize dependabot usage in our repo

## ✅ What was done

- [X] Adds 7 days cooldown 
- [X] Adds 1 PR limit 
- [X] Customizes dependabot not to suggest major version updates; we should do those ourselves
- [X] Customizes dependabot to analyze GitHub actions in our workflows as well

## 🔗 Related issue

Closes: #773