### PR TITLE
Updates sign in confirmation page

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@grconrad/vscode-extension-feedback": "1.0.0",
-        "@pnp/cli-microsoft365-spfx-toolkit": "1.12.0",
+        "@pnp/cli-microsoft365-spfx-toolkit": "1.13.0",
         "node-forge": "1.4.0",
         "react-markdown": "10.1.0",
         "rehype-raw": "7.0.0",
@@ -1544,9 +1544,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365-spfx-toolkit": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365-spfx-toolkit/-/cli-microsoft365-spfx-toolkit-1.12.0.tgz",
-      "integrity": "sha512-ucd/5q9VOb+A2/3yB55bI+Ric79pmbfg/Up+DozF2x4zTaLi5z/zeRTQUXtvZQKkOB1vgb9ZHoG8tbKsgoPfsA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365-spfx-toolkit/-/cli-microsoft365-spfx-toolkit-1.13.0.tgz",
+      "integrity": "sha512-GuROpe+3BTPAnIKWToXIWwzMhmfNVlN9n3noWR7ksBgDEDNAqaE82mJyxt4OrYsGC4/fVD6bYMdVJGrPw1W95Q==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1619,7 +1619,7 @@
   },
   "dependencies": {
     "@grconrad/vscode-extension-feedback": "1.0.0",
-    "@pnp/cli-microsoft365-spfx-toolkit": "1.12.0",
+    "@pnp/cli-microsoft365-spfx-toolkit": "1.13.0",
     "node-forge": "1.4.0",
     "react-markdown": "10.1.0",
     "remark-gfm": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1757,7 +1757,7 @@
   },
   "dependencies": {
     "@grconrad/vscode-extension-feedback": "1.0.0",
-    "@pnp/cli-microsoft365-spfx-toolkit": "1.12.0",
+    "@pnp/cli-microsoft365-spfx-toolkit": "1.13.0",
     "node-forge": "1.4.0",
     "react-markdown": "10.1.0",
     "remark-gfm": "4.0.1",


### PR DESCRIPTION
## 🎯 Aim

Is to update the sign in confirmation page to something a bit nicer. Now it is a standard HTML page with a single text and does not look profesional.

## 🧪 How to test

since mode of the change was done on CLI for M365 for SPFx Toolkit npm package side, you simply need to pull the changes, run npm ci and run the VS Code extension in debug and perform sign in

## 📷 Result

new sign in confirmation page 
<img width="1392" height="762" alt="image" src="https://github.com/user-attachments/assets/a5fcae18-1e2c-4d37-bd78-ecd0de7fb925" />

after a short wait it will redirect to https://spfxtoolkit.community.ms/


