### PR TITLE
Fixes docs header. Closes #858

### DIFF
--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -3,7 +3,8 @@
 }
 
 .site-title img {
-    width: 350;
+    width: auto;
+    max-width: 2.5rem;
 }
 
 .hero {


### PR DESCRIPTION
## 🎯 Aim

The aim is to fix a small styling issue in the docs header described in the related issue

## 📷 Result

<img width="932" height="719" alt="{E0B6413D-5E7F-4538-8A3C-7BF0EB873779}" src="https://github.com/user-attachments/assets/51518669-c36e-4e93-b400-eb3f50920bee" />


## ✅ What was done

- [X] fixed styling

## 🔗 Related issue

Closes #858