### PR TITLE
Add update_spo_list Language Model Tool for SharePoint List updates. …

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ The extension provides the following tools
 | SharePointListGet                 | Gets information about the specific list                  |
 | SharePointListList                | Lists lists in the specified site                         |
 | SharePointListRemove              | Removes the specified list                                |
+| SharePointListSet                 | Updates the specified list                                |
 | SharePointPageAdd                 | Creates a page                                            |
 | SharePointPageGet                 | Gets information about the specific page                  |
 | SharePointPageList                | Lists pages in the specified site                         |

--- a/docs/src/content/docs/features/github-copilot-capabilities.mdx
+++ b/docs/src/content/docs/features/github-copilot-capabilities.mdx
@@ -32,6 +32,7 @@ The extension provides the following tools
 | SharePointListGet                 | Gets information about the specific list                  |
 | SharePointListList                | Lists lists in the specified site                         |
 | SharePointListRemove              | Removes the specified list                                |
+| SharePointListSet                 | Updates the specified list                                |
 | SharePointPageAdd                 | Creates a page                                            |
 | SharePointPageGet                 | Gets information about the specific page                  |
 | SharePointPageList                | Lists pages in the specified site                         |

--- a/package.json
+++ b/package.json
@@ -407,6 +407,110 @@
         }
       },
       {
+        "name": "update_spo_list",
+        "tags": [
+          "sharepoint",
+          "list",
+          "spfx-toolkit"
+        ],
+        "toolReferenceName": "SharePointListSet",
+        "displayName": "Update a SharePoint list",
+        "modelDescription": "Updates settings of an existing SharePoint list or document library, such as its title, description, versioning, content types, commenting, and other configuration properties. Returns confirmation once the update completes; the underlying command does not return the updated list object. Use this tool when you need to change the configuration of a list that already exists. Do not use this tool to create a new list (use add_spo_list instead) or to work with list items. The list to update must be identified by exactly one of id, title, or url together with webUrl. The list's base template (e.g. GenericList, DocumentLibrary) cannot be changed once created. Requires Microsoft 365 authentication and permissions to manage the list on the target site.",
+        "userDescription": "Updates the settings of the specified list.",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(edit)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "webUrl": {
+              "type": "string",
+              "description": "URL of the site where the list to update is located. This option is required.",
+              "default": ""
+            },
+            "id": {
+              "type": "string",
+              "description": "ID of the list to update. Specify only one of id, title, or url. This option is optional.",
+              "default": ""
+            },
+            "title": {
+              "type": "string",
+              "description": "Title of the list to update. Specify only one of id, title, or url. This option is optional.",
+              "default": ""
+            },
+            "url": {
+              "type": "string",
+              "description": "Server-relative URL of the list to update. Specify only one of id, title, or url. This option is optional.",
+              "default": ""
+            },
+            "newTitle": {
+              "type": "string",
+              "description": "New title to set for the list. This option is optional.",
+              "default": ""
+            },
+            "description": {
+              "type": "string",
+              "description": "The description to set for the list. This option is optional.",
+              "default": ""
+            },
+            "allowDeletion": {
+              "type": "boolean",
+              "description": "Specifies whether the list can be deleted. This option is optional.",
+              "default": false
+            },
+            "contentTypesEnabled": {
+              "type": "boolean",
+              "description": "Specifies whether content types are enabled for the list. This option is optional.",
+              "default": false
+            },
+            "disableCommenting": {
+              "type": "boolean",
+              "description": "Specifies whether commenting on list items is disabled. This option is optional.",
+              "default": false
+            },
+            "disableGridEditing": {
+              "type": "boolean",
+              "description": "Specifies whether grid editing is disabled for the list. This option is optional.",
+              "default": false
+            },
+            "draftVersionVisibility": {
+              "type": "string",
+              "description": "Specifies the visibility of draft versions in the list. Allowed values: Reader, Author, Approver. This option is optional.",
+              "default": ""
+            },
+            "enableFolderCreation": {
+              "type": "boolean",
+              "description": "Specifies whether folder creation is enabled for the list. This option is optional.",
+              "default": false
+            },
+            "enableMinorVersions": {
+              "type": "boolean",
+              "description": "Specifies whether minor versions are enabled for the list. This option is optional.",
+              "default": false
+            },
+            "enableVersioning": {
+              "type": "boolean",
+              "description": "Specifies whether versioning is enabled for the list. This option is optional.",
+              "default": false
+            },
+            "forceCheckout": {
+              "type": "boolean",
+              "description": "Specifies whether forced checkout is enabled for the list. This option is optional.",
+              "default": false
+            },
+            "hidden": {
+              "type": "boolean",
+              "description": "Specifies whether the list is hidden from the browser. This option is optional.",
+              "default": false
+            },
+            "noCrawl": {
+              "type": "boolean",
+              "description": "Specifies whether the list should be excluded from search crawling. This option is optional.",
+              "default": false
+            }
+          }
+        }
+      },
+      {
         "name": "add_spo_page",
         "tags": [
           "sharepoint",

--- a/src/chat/tools/ChatTools.ts
+++ b/src/chat/tools/ChatTools.ts
@@ -11,6 +11,7 @@ import {
     SharePointListGet,
     SharePointListList,
     SharePointListRemove,
+    SharePointListSet,
     SharePointPageAdd,
     SharePointPageCopy,
     SharePointPageGet,
@@ -53,6 +54,9 @@ export class ChatTools {
         );
         subscriptions.push(
             lm.registerTool('remove_spo_list', new SharePointListRemove())
+        );
+        subscriptions.push(
+            lm.registerTool('update_spo_list', new SharePointListSet())
         );
         subscriptions.push(
             lm.registerTool('add_spo_page', new SharePointPageAdd())

--- a/src/chat/tools/spo/index.ts
+++ b/src/chat/tools/spo/index.ts
@@ -7,6 +7,7 @@ export * from './list/ListAdd';
 export * from './list/ListGet';
 export * from './list/ListList';
 export * from './list/ListRemove';
+export * from './list/ListSet';
 export * from './page/PageAdd';
 export * from './page/PageCopy';
 export * from './page/PageGet';

--- a/src/chat/tools/spo/list/ListSet.ts
+++ b/src/chat/tools/spo/list/ListSet.ts
@@ -1,0 +1,59 @@
+import { CancellationToken, LanguageModelTextPart, LanguageModelTool, LanguageModelToolInvocationOptions, LanguageModelToolInvocationPrepareOptions, LanguageModelToolResult, MarkdownString } from 'vscode';
+import { CliExecuter } from '../../../../services/executeWrappers/CliCommandExecuter';
+import { validateAuth } from '../utils/ToolAuthValidationUtil';
+
+
+interface ISharePointListSetParameters {
+    webUrl: string;
+    id?: string;
+    title?: string;
+    url?: string;
+    newTitle?: string;
+    description?: string;
+    allowDeletion?: boolean;
+    contentTypesEnabled?: boolean;
+    disableCommenting?: boolean;
+    disableGridEditing?: boolean;
+    draftVersionVisibility?: string;
+    enableFolderCreation?: boolean;
+    enableMinorVersions?: boolean;
+    enableVersioning?: boolean;
+    forceCheckout?: boolean;
+    hidden?: boolean;
+    noCrawl?: boolean;
+}
+
+export class SharePointListSet implements LanguageModelTool<ISharePointListSetParameters> {
+    async invoke(
+        options: LanguageModelToolInvocationOptions<ISharePointListSetParameters>,
+        _token: CancellationToken
+    ) {
+        const params = options.input;
+        const authValidationResult = await validateAuth();
+        if (authValidationResult !== true) {
+            return authValidationResult as LanguageModelToolResult;
+        }
+
+        const result = await CliExecuter.execute('spo list set', 'json', params);
+        if (result.stderr) {
+            return new LanguageModelToolResult([new LanguageModelTextPart(`Error: ${result.stderr}`)]);
+        }
+
+        return new LanguageModelToolResult([new LanguageModelTextPart(`List updated successfully${(result.stdout !== '' ? `\nResult: ${result.stdout}` : '')}`)]);
+    }
+
+    async prepareInvocation(
+        options: LanguageModelToolInvocationPrepareOptions<ISharePointListSetParameters>,
+        _token: CancellationToken
+    ) {
+        const confirmationMessages = {
+            title: 'Update a SharePoint Online list',
+            message: new MarkdownString('Should I update the list with the following parameters?'),
+        };
+
+        return {
+            invocationMessage: 'Updating a SharePoint Online list',
+            confirmationMessages,
+        };
+    }
+}


### PR DESCRIPTION
## 🎯 Aim

> This PR adds a language model tool to update properties of a list or library on a specific site. This tool updates the same properties that are available in add_spo_list tool. It doesn't support updating all properties available in [https://pnp.github.io/cli-microsoft365/cmd/spo/list/list-set/](https://pnp.github.io/cli-microsoft365/cmd/spo/list/list-set/)

## 📷 Result

> <img width="447" height="420" alt="image" src="https://github.com/user-attachments/assets/ecb111a4-c073-45dd-8b89-064656737522" />

## ✅ What was done

- [X] Added update_spo_list tool in package.json
 - [X] Registered tool in ChatTools.ts
- [X]  Impemented SharePointListSet class

## 🔗 Related issue

Closes: #595 