### PR TITLE
Updates CI/CD action to support multiple SPFx versions. Closes #682 #523 #514

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@grconrad/vscode-extension-feedback": "1.0.0",
-        "@pnp/cli-microsoft365-spfx-toolkit": "1.13.0",
+        "@pnp/cli-microsoft365-spfx-toolkit": "1.14.0",
         "node-forge": "1.4.0",
         "react-markdown": "10.1.0",
         "rehype-raw": "7.0.0",
@@ -1544,9 +1544,9 @@
       }
     },
     "node_modules/@pnp/cli-microsoft365-spfx-toolkit": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365-spfx-toolkit/-/cli-microsoft365-spfx-toolkit-1.13.0.tgz",
-      "integrity": "sha512-GuROpe+3BTPAnIKWToXIWwzMhmfNVlN9n3noWR7ksBgDEDNAqaE82mJyxt4OrYsGC4/fVD6bYMdVJGrPw1W95Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@pnp/cli-microsoft365-spfx-toolkit/-/cli-microsoft365-spfx-toolkit-1.14.0.tgz",
+      "integrity": "sha512-+ZLoiRMJym37vLqG529tZ5EdNBNLYTA6NZ+gujqQaHHeLjW5eP5nJHxNYa2xD0D+2LF+d4Uq2JxLHle7PxiwEw==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1757,7 +1757,7 @@
   },
   "dependencies": {
     "@grconrad/vscode-extension-feedback": "1.0.0",
-    "@pnp/cli-microsoft365-spfx-toolkit": "1.13.0",
+    "@pnp/cli-microsoft365-spfx-toolkit": "1.14.0",
     "node-forge": "1.4.0",
     "react-markdown": "10.1.0",
     "remark-gfm": "4.0.1",


### PR DESCRIPTION
## 🎯 Aim

The aim of this PR is to upgrade CLI for the Microsoft 365 SPFx Toolkit package to latest in which I aligned all CI/CD command fixes. Now it will allow generating a pipeline/workflow for any SPFx version also using heft (npm run build) for newer versions of SPFx and gulp for older versions.

## 🔗 Related issue

Closes #682 #523 #514